### PR TITLE
feat: re-use postcss ast if passed from previous loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "loader-utils": "^1.1.0",
     "postcss": "^7.0.0",
     "postcss-load-config": "^2.0.0",
-    "schema-utils": "^1.0.0"
+    "schema-utils": "^1.0.0",
+    "semver": "^6.3.0"
   },
   "devDependencies": {
     "@webpack-utilities/test": "^1.0.0-alpha.0",

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Loader Default 1`] = `"module.exports = \\"a { color: black }\\\\n\\""`;
+
+exports[`Loader Loader - Previous AST 1`] = `"module.exports = \\"a {\\\\n    color: yellow\\\\n}\\""`;
+
+exports[`Loader uses previous AST 1`] = `"module.exports = \\"a {\\\\n    color: yellow\\\\n}\\""`;

--- a/test/ast-loader.js
+++ b/test/ast-loader.js
@@ -1,0 +1,28 @@
+const postcss = require('postcss')
+const postcssPkg = require('postcss/package.json')
+const semver = require('semver')
+
+const incomingVersion = semver.inc(postcssPkg.version, 'minor')
+
+module.exports = function astLoader (content) {
+  const callback = this.async()
+
+  const { spy = jest.fn() } = this.query
+
+  content = this.exec(content, this.resource)
+
+  postcss()
+    .process(content, { parser: require('postcss-js') })
+    .then(({ css, map, root, messages }) => {
+      const ast = {
+        type: 'postcss',
+        version: incomingVersion
+      }
+
+      Object.defineProperty(ast, 'root', {
+        get: spy.mockReturnValue(root)
+      })
+
+      callback(null, css, map, { ast, messages })
+    })
+}

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,5 +1,4 @@
 const { webpack } = require('@webpack-utilities/test')
-
 describe('Loader', () => {
   test('Default', () => {
     const config = {
@@ -15,6 +14,34 @@ describe('Loader', () => {
       const { source } = stats.toJson().modules[1]
 
       expect(source).toEqual('module.exports = "a { color: black }\\n"')
+      expect(source).toMatchSnapshot()
+    })
+  })
+
+  test('Loader - Previous AST', () => {
+    const spy = jest.fn()
+    const config = {
+      rules: [
+        {
+          test: /style\.js$/,
+          use: [
+            {
+              loader: require.resolve('../src'),
+              options: { importLoaders: 1 }
+            },
+            {
+              loader: require.resolve('./ast-loader'),
+              options: { spy }
+            }
+          ]
+        }
+      ]
+    }
+
+    return webpack('jss/index.js', config).then((stats) => {
+      const { source } = stats.toJson().modules[1]
+
+      expect(spy).toHaveBeenCalledTimes(1)
       expect(source).toMatchSnapshot()
     })
   })


### PR DESCRIPTION
### Notable Changes

Allows reusing a postcss AST if the previous loader passed it. Same logic as css-loader, accepts semver compatible AST versions. It skips doing parser specific logic, since a previous AST makes parsing irrelevant 

### Type

> ℹ️ What type of changes does your code introduce?

<!-- 👉 Put an `x` in the boxes that apply and delete all others -->

- [ ] CI
- [ ] Fix
- [ ] Perf
- [ ] Docs
- [x] Test
- [ ] Style
- [ ] Build
- [ ] Chore
- [x] Feature
- [ ] Refactor


### SemVer

> ℹ️  What changes to the current `semver` range does your PR introduce?

<!-- 👉  Put an `x` in the boxes that apply and delete all others -->

- [ ] Fix (:label: Patch)
- [x] Feature (:label: Minor)
- [ ] Breaking Change (:label: Major)

### Checklist

> ℹ️  You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is a reminder of what we are going to look for before merging your code.

<!-- 👉  Put an `x` in the boxes that apply and delete all others -->

- [x] Lint and unit tests pass with my changes
- [x] I have added tests that prove my fix is effective/works (if needed)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules
