### PR TITLE
chore!: drop node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ jobs:
       node_js: 'stable'
     - <<: *test
       node_js: 'lts/*'
-    - <<: *test
-      node_js: 6
 
 script: npm run $SCRIPT
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "src"
   ],
   "engines": {
-    "node": ">= 6"
+    "node": ">= 10.13"
   },
   "dependencies": {
     "loader-utils": "^1.1.0",


### PR DESCRIPTION
I'm not even sure this is actually breaking, `postcss` and `webpack` already don't support node 6 so unclear if anyone could even use this with node 6

- [ ] CI
- [ ] Fix
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Style
- [ ] Build
- [x] Chore
- [ ] Feature
- [ ] Refactor

### Issues

> ℹ️ What issue(s) (if any) are closed by your PR?

<!-- 👉 Replace `#1` with the issue number that applies and remove the ``` `  ``` (`#1` => #1) -->

- Fixes `#1`

### SemVer

> ℹ️  What changes to the current `semver` range does your PR introduce?

<!-- 👉  Put an `x` in the boxes that apply and delete all others -->

- [ ] Fix (:label: Patch)
- [ ] Feature (:label: Minor)
- [x] Breaking Change (:label: Major)

### Checklist

> ℹ️  You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. This is a reminder of what we are going to look for before merging your code.

<!-- 👉  Put an `x` in the boxes that apply and delete all others -->

- [x] Lint and unit tests pass with my changes
- [ ] I have added tests that prove my fix is effective/works (if needed)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules
