### PR TITLE
Extract postcss options

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,7 +760,7 @@ module.exports = {
             loader: 'postcss-loader',
             options: {
               postcssOptions: {
-                 plugins: [['autoprefixer', { ...options }]],
+                plugins: [['autoprefixer', { ...options }]],
               },
             },
           },

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ npm i -D postcss-loader
 ```js
 module.exports = {
   parser: 'sugarss',
-  plugins: [['postcss-import', {}], ['postcss-preset-env'], 'postcss-short'],
+  plugins: {
+    'postcss-import': {},
+    'postcss-preset-env': {},
+    cssnano: {},
+  },
 };
 ```
 
@@ -109,15 +113,12 @@ module.exports = {
 
 <h2 align="center">Options</h2>
 
-|            Name            |                             Type                             |      Default       | Description                                  |
-| :------------------------: | :----------------------------------------------------------: | :----------------: | :------------------------------------------- |
-|      [`exec`](#exec)       |                         `{Boolean}`                          |    `undefined`     | Enable PostCSS Parser support in `CSS-in-JS` |
-|   [`parser`](#syntaxes)    |                 `{String\|Object\|Function}`                 |    `undefined`     | Set PostCSS Parser                           |
-|   [`syntax`](#syntaxes)    |                      `{String\|Object}`                      |    `undefined`     | Set PostCSS Syntax                           |
-| [`stringifier`](#syntaxes) |                 `{String\|Object\|Function}`                 |    `undefined`     | Set PostCSS Stringifier                      |
-|    [`config`](#config)     |                 `{String\|Object\|Boolean}`                  |    `undefined`     | Set `postcss.config.js` config path && `ctx` |
-|   [`plugins`](#plugins)    | `{Function\|Object\|Array<String\|Function\|Object\|Array>}` |        `[]`        | Set PostCSS Plugins                          |
-| [`sourceMap`](#sourcemap)  |                     `{String\|Boolean}`                      | `compiler.devtool` | Enables/Disables generation of source maps   |
+|                Name                 |            Type             |                Default                | Description                                     |
+| :---------------------------------: | :-------------------------: | :-----------------------------------: | :---------------------------------------------- |
+|           [`exec`](#exec)           |         `{Boolean}`         |              `undefined`              | Enable PostCSS Parser support in `CSS-in-JS`    |
+|         [`config`](#config)         | `{String\|Object\|Boolean}` |              `undefined`              | Set `postcss.config.js` config path && `ctx`    |
+| [`postcssOptions`](#postcssOptions) |         `{Object}`          | `defaults values for Postcss.process` | Set Postcss.process options and postcss plugins |
+|      [`sourceMap`](#sourcemap)      |     `{String\|Boolean}`     |          `compiler.devtool`           | Enables/Disables generation of source maps      |
 
 ### `Exec`
 
@@ -139,7 +140,12 @@ module.exports = {
           { loader: 'css-loader', options: { importLoaders: 1 } },
           {
             loader: 'postcss-loader',
-            options: { parser: 'sugarss', exec: true },
+            options: {
+              postcssOptions: {
+                parser: 'sugarss',
+              },
+              exec: true,
+            },
           },
         ],
       },
@@ -290,7 +296,16 @@ module.exports = {
 };
 ```
 
-### `Plugins`
+### `postcssOptions`
+
+|             Name              |                     Type                      |   Default   | Description                    |
+| :---------------------------: | :-------------------------------------------: | :---------: | :----------------------------- |
+|     [`plugins`](#plugins)     | `{Function\|Object\|Array<Function\|Object>}` |    `[]`     | Set PostCSS Plugins            |
+|      [`parser`](#parser)      |         `{String\|Object\|Function}`          | `undefined` | Set custom PostCSS Parser      |
+|      [`syntax`](#syntax)      |              `{String\|Object}`               | `undefined` | Set custom PostCSS Syntax      |
+| [`stringifier`](#stringifier) |         `{String\|Object\|Function}`          | `undefined` | Set custom PostCSS Stringifier |
+
+#### `Plugins`
 
 Type: `Function|Object|Array<String|Function\|Object|Array>`
 Default: `[]`
@@ -352,11 +367,13 @@ module.exports = {
         test: /\.css$/i,
         loader: 'postcss-loader',
         options: {
-          plugins: (loader) => [
-            require('postcss-import')({ root: loader.resourcePath }),
-            require('postcss-preset-env')(),
-            require('cssnano')(),
-          ],
+          postcssOptions: {
+            plugins: (loader) => [
+              require('postcss-import')({ root: loader.resourcePath }),
+              require('postcss-preset-env')(),
+              require('cssnano')(),
+            ],
+          },
         },
       },
     ],
@@ -394,11 +411,11 @@ It is possible to disable the plugin specified in the config.
 
 ```js
 module.exports = {
-  plugins: [
-    ['postcss-short', { prefix: 'x' }],
-    'postcss-import',
-    'postcss-nested',
-  ],
+  plugins: {
+    'postcss-short': { prefix: 'x' },
+    'postcss-import': {},
+    'postcss-nested': {},
+  },
 };
 ```
 
@@ -412,11 +429,13 @@ module.exports = {
         test: /\.css$/i,
         loader: 'postcss-loader',
         options: {
-          plugins: {
-            'postcss-import': {},
-            'postcss-nested': {},
-            // Turn off the plugin
-            'postcss-short': false,
+          postcssOptions: {
+            plugins: {
+              'postcss-import': {},
+              'postcss-nested': {},
+              // Turn off the plugin
+              'postcss-short': false,
+            },
           },
         },
       },
@@ -424,17 +443,6 @@ module.exports = {
   },
 };
 ```
-
-### `Syntaxes`
-
-Type: `String|Object`
-Default: `undefined`
-
-|             Name              |             Type             |   Default   | Description                |
-| :---------------------------: | :--------------------------: | :---------: | :------------------------- |
-|      [`parser`](#parser)      |      `{String\|Object}`      | `undefined` | Custom PostCSS Parser      |
-|      [`syntax`](#syntax)      |      `{String\|Object}`      | `undefined` | Custom PostCSS Syntax      |
-| [`stringifier`](#stringifier) | `{String\|Object\|Function}` | `undefined` | Custom PostCSS Stringifier |
 
 #### `Parser`
 
@@ -455,8 +463,10 @@ module.exports = {
         test: /\.sss$/i,
         loader: 'postcss-loader',
         options: {
-          // Will be converted to `require('sugarss')`
-          parser: 'sugarss',
+          postcssOptions: {
+            // Will be converted to `require('sugarss')`
+            parser: 'sugarss',
+          },
         },
       },
     ],
@@ -476,7 +486,9 @@ module.exports = {
         test: /\.sss$/i,
         loader: 'postcss-loader',
         options: {
-          parser: require('sugarss'),
+          postcssOptions: {
+            parser: require('sugarss'),
+          },
         },
       },
     ],
@@ -496,7 +508,9 @@ module.exports = {
         test: /\.sss$/i,
         loader: 'postcss-loader',
         options: {
-          parser: require('sugarss').parse,
+          postcssOptions: {
+            parser: require('sugarss').parse,
+          },
         },
       },
     ],
@@ -523,8 +537,10 @@ module.exports = {
         test: /\.css$/i,
         loader: 'postcss-loader',
         options: {
-          // Will be converted to `require('sugarss')`
-          syntax: 'sugarss',
+          postcssOptions: {
+            // Will be converted to `require('sugarss')`
+            syntax: 'sugarss',
+          },
         },
       },
     ],
@@ -544,7 +560,9 @@ module.exports = {
         test: /\.css$/i,
         loader: 'postcss-loader',
         options: {
-          stringifier: require('sugarss'),
+          postcssOptions: {
+            stringifier: require('sugarss'),
+          },
         },
       },
     ],
@@ -571,8 +589,10 @@ module.exports = {
         test: /\.css$/i,
         loader: 'postcss-loader',
         options: {
-          // Will be converted to `require('sugarss')`
-          stringifier: 'sugarss',
+          postcssOptions: {
+            // Will be converted to `require('sugarss')`
+            stringifier: 'sugarss',
+          },
         },
       },
     ],
@@ -592,7 +612,9 @@ module.exports = {
         test: /\.css$/i,
         loader: 'postcss-loader',
         options: {
-          stringifier: require('sugarss'),
+          postcssOptions: {
+            stringifier: require('sugarss'),
+          },
         },
       },
     ],
@@ -615,7 +637,9 @@ module.exports = {
         test: /\.css$/i,
         loader: 'postcss-loader',
         options: {
-          stringifier: midas.stringifier,
+          postcssOptions: {
+            stringifier: midas.stringifier,
+          },
         },
       },
     ],
@@ -707,7 +731,9 @@ module.exports = {
           {
             loader: 'postcss-loader',
             options: {
-              plugins: ['postcss-import', 'stylelint'],
+              postcssOptions: {
+                plugins: ['postcss-import', 'stylelint'],
+              },
             },
           },
         ],
@@ -733,7 +759,9 @@ module.exports = {
           {
             loader: 'postcss-loader',
             options: {
-              plugins: [['autoprefixer', { ...options }]],
+              postcssOptions: {
+                 plugins: [['autoprefixer', { ...options }]],
+              },
             },
           },
         ],
@@ -797,7 +825,14 @@ module.exports = {
         use: [
           'style-loader',
           { loader: 'css-loader', options: { importLoaders: 2 } },
-          { loader: 'postcss-loader', options: { parser: 'postcss-js' } },
+          {
+            loader: 'postcss-loader',
+            options: {
+              postcssOptions: {
+                parser: 'postcss-js',
+              },
+            },
+          },
           'babel-loader',
         ],
       },
@@ -896,7 +931,9 @@ module.exports = {
           {
             loader: 'postcss-loader',
             options: {
-              plugins: [postcssPlugin()],
+              postcssOptions: {
+                plugins: [postcssPlugin()],
+              },
             },
           },
         ],
@@ -942,7 +979,9 @@ module.exports = {
           {
             loader: 'postcss-loader',
             options: {
-              plugins: [postcssPlugin()],
+              postcssOptions: {
+                plugins: [postcssPlugin()],
+              },
             },
           },
         ],
@@ -982,7 +1021,9 @@ module.exports = {
 
 ```js
 module.exports = (loaderContext) => ({
-  plugins: [require('path/to/customPlugin')(loaderContext)],
+  postcssOptions: {
+    plugins: [require('path/to/customPlugin')(loaderContext)],
+  },
 });
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -82,14 +82,17 @@ export default async function loader(content, sourceMap, meta = {}) {
     }
   }
 
+  loadedConfig.postcssOptions = loadedConfig.postcssOptions || {};
+  options.postcssOptions = options.postcssOptions || {};
+
   let plugins;
 
   const disabledPlugins = [];
 
   try {
     plugins = [
-      ...getArrayPlugins(loadedConfig.plugins, file, false, this),
-      ...getArrayPlugins(options.plugins, file, disabledPlugins, this),
+      ...getArrayPlugins(loadedConfig.postcssOptions.plugins, file, false, this),
+      ...getArrayPlugins(options.postcssOptions.plugins, file, disabledPlugins, this),
     ].filter((i) => !disabledPlugins.includes(i.postcssPlugin));
   } catch (error) {
     this.emitError(error);
@@ -101,9 +104,9 @@ export default async function loader(content, sourceMap, meta = {}) {
     plugins,
   };
 
-  const resultPlugins = mergedOptions.plugins;
+  mergedOptions.postcssOptions.plugins = plugins;
 
-  const { parser, syntax, stringifier } = mergedOptions;
+  const resultPlugins = mergedOptions.postcssOptions.plugins;
 
   const useSourceMap =
     typeof options.sourceMap !== 'undefined'
@@ -127,9 +130,7 @@ export default async function loader(content, sourceMap, meta = {}) {
         ? { inline: true, annotation: false }
         : { inline: false, annotation: false }
       : false,
-    parser,
-    syntax,
-    stringifier,
+    ...mergedOptions.postcssOptions,
   };
 
   if (postcssOptions.map && sourceMapNormalized) {

--- a/src/index.js
+++ b/src/index.js
@@ -40,10 +40,14 @@ export default async function loader(content, sourceMap, meta = {}) {
 
   const callback = this.async();
   const file = this.resourcePath;
-  let loadedConfig = {};
 
   const configOptions =
-    typeof options.config === 'undefined' ? true : options.config;
+    typeof options.postcssOptions === 'undefined' ||
+    typeof options.postcssOptions.config === 'undefined'
+      ? true
+      : options.postcssOptions.config;
+
+  let loadedConfig = {};
 
   if (configOptions) {
     const dataForLoadConfig = {
@@ -82,7 +86,6 @@ export default async function loader(content, sourceMap, meta = {}) {
     }
   }
 
-  loadedConfig.postcssOptions = loadedConfig.postcssOptions || {};
   options.postcssOptions = options.postcssOptions || {};
 
   let plugins;
@@ -91,8 +94,13 @@ export default async function loader(content, sourceMap, meta = {}) {
 
   try {
     plugins = [
-      ...getArrayPlugins(loadedConfig.postcssOptions.plugins, file, false, this),
-      ...getArrayPlugins(options.postcssOptions.plugins, file, disabledPlugins, this),
+      ...getArrayPlugins(loadedConfig.plugins, file, false, this),
+      ...getArrayPlugins(
+        options.postcssOptions.plugins,
+        file,
+        disabledPlugins,
+        this
+      ),
     ].filter((i) => !disabledPlugins.includes(i.postcssPlugin));
   } catch (error) {
     this.emitError(error);
@@ -137,8 +145,6 @@ export default async function loader(content, sourceMap, meta = {}) {
     postcssOptions.map.prev = sourceMapNormalized;
   }
 
-  // Loader Exec (Deprecated)
-  // https://webpack.js.org/api/loaders/#deprecated-context-properties
   if (postcssOptions.parser === 'postcss-js') {
     // eslint-disable-next-line no-param-reassign
     content = exec(content, this);
@@ -146,7 +152,7 @@ export default async function loader(content, sourceMap, meta = {}) {
 
   if (typeof postcssOptions.parser === 'string') {
     try {
-      // eslint-disable-next-line import/no-dynamic-require,global-require
+      // eslint-disable-next-line import/no-dynamic-require, global-require
       postcssOptions.parser = require(postcssOptions.parser);
     } catch (error) {
       this.emitError(
@@ -157,7 +163,7 @@ export default async function loader(content, sourceMap, meta = {}) {
 
   if (typeof postcssOptions.syntax === 'string') {
     try {
-      // eslint-disable-next-line import/no-dynamic-require,global-require
+      // eslint-disable-next-line import/no-dynamic-require, global-require
       postcssOptions.syntax = require(postcssOptions.syntax);
     } catch (error) {
       this.emitError(
@@ -168,7 +174,7 @@ export default async function loader(content, sourceMap, meta = {}) {
 
   if (typeof postcssOptions.stringifier === 'string') {
     try {
-      // eslint-disable-next-line import/no-dynamic-require,global-require
+      // eslint-disable-next-line import/no-dynamic-require, global-require
       postcssOptions.stringifier = require(postcssOptions.stringifier);
     } catch (error) {
       this.emitError(
@@ -177,8 +183,6 @@ export default async function loader(content, sourceMap, meta = {}) {
     }
   }
 
-  // Loader API Exec (Deprecated)
-  // https://webpack.js.org/api/loaders/#deprecated-context-properties
   if (mergedOptions.exec) {
     // eslint-disable-next-line no-param-reassign
     content = exec(content, this);
@@ -226,7 +230,7 @@ export default async function loader(content, sourceMap, meta = {}) {
 
   map = map ? map.toJSON() : null;
 
-  if (map) {
+  if (map && useSourceMap) {
     if (typeof map.file !== 'undefined') {
       delete map.file;
     }

--- a/src/options.json
+++ b/src/options.json
@@ -1,18 +1,79 @@
 {
   "type": "object",
   "properties": {
+    "postcssOptions": {
+      "description": "Options to pass through to `Postcss`.",
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "parser": {
+              "description": "Allows to specify custom Postcss Parser (https://github.com/postcss/postcss-loader#parser)",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "instanceof": "Function"
+                }
+              ]
+            },
+            "syntax": {
+              "description": "Allows to specify custom Postcss Syntax (https://github.com/postcss/postcss-loader#syntax)",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object"
+                }
+              ]
+            },
+            "stringifier": {
+              "description": "Allows to specify custom Postcss stringifier (https://github.com/postcss/postcss-loader#stringifier)",
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object"
+                },
+                {
+                  "instanceof": "Function"
+                }
+              ]
+            },
+            "plugins": {
+              "description": "Set PostCSS Plugins (https://github.com/postcss/postcss-loader#plugins)",
+              "anyOf": [
+                { "type": "array" },
+                { "type": "object" },
+                { "instanceof": "Function" }
+              ]
+            }
+          }
+        },
+        {
+          "instanceof": "Function"
+        }
+      ]
+    },
     "config": {
-      "description": "should be {Object} (https://github.com/postcss/postcss-loader#config)",
+      "description": "Allows to specify PostCSS Config Path (https://github.com/postcss/postcss-loader#config)",
       "anyOf": [
         {
           "type": "object",
           "properties": {
             "path": {
-              "description": "should be {String} (https://github.com/postcss/postcss-loader#path)",
+              "description": "Allows to specify PostCSS Config Path (https://github.com/postcss/postcss-loader#path)",
               "type": "string"
             },
             "ctx": {
-              "description": "should be {Object} (https://github.com/postcss/postcss-loader#context-ctx)",
+              "description": "Allows to specify PostCSS Config Context (https://github.com/postcss/postcss-loader#context-ctx)",
               "type": "object"
             }
           },
@@ -29,58 +90,11 @@
       ]
     },
     "exec": {
-      "description": "should be {Boolean} (https://github.com/postcss/postcss-loader#exec)",
+      "description": "Enable PostCSS Parser support in 'CSS-in-JS' (https://github.com/postcss/postcss-loader#exec)",
       "type": "boolean"
     },
-    "parser": {
-      "description": "should be {String|Object} (https://github.com/postcss/postcss-loader#parser)",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "object"
-        },
-        {
-          "instanceof": "Function"
-        }
-      ]
-    },
-    "syntax": {
-      "description": "should be {String|Object} (https://github.com/postcss/postcss-loader#syntax)",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "object"
-        }
-      ]
-    },
-    "stringifier": {
-      "description": "should be {String|Object} (https://github.com/postcss/postcss-loader#stringifier)",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "object"
-        },
-        {
-          "instanceof": "Function"
-        }
-      ]
-    },
-    "plugins": {
-      "description": "should be {Array|Object|Function} (https://github.com/postcss/postcss-loader#plugins)",
-      "anyOf": [
-        { "type": "array" },
-        { "type": "object" },
-        { "instanceof": "Function" }
-      ]
-    },
     "sourceMap": {
-      "description": "should be {String|Boolean} (https://github.com/postcss/postcss-loader#sourcemap)",
+      "description": "Enables/Disables generation of source maps (https://github.com/postcss/postcss-loader#sourcemap)",
       "anyOf": [
         {
           "type": "string"

--- a/src/options.json
+++ b/src/options.json
@@ -8,6 +8,33 @@
           "type": "object",
           "additionalProperties": true,
           "properties": {
+            "config": {
+              "description": "Allows to specify PostCSS Config Path (https://github.com/postcss/postcss-loader#config)",
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "description": "Allows to specify PostCSS Config Path (https://github.com/postcss/postcss-loader#path)",
+                      "type": "string"
+                    },
+                    "ctx": {
+                      "description": "Allows to specify PostCSS Config Context (https://github.com/postcss/postcss-loader#context-ctx)",
+                      "type": "object"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "description": "Allows to specify the path to the configuration file",
+                  "type": "string"
+                },
+                {
+                  "description": "Enables/Disables autoloading config",
+                  "type": "boolean"
+                }
+              ]
+            },
             "parser": {
               "description": "Allows to specify custom Postcss Parser (https://github.com/postcss/postcss-loader#parser)",
               "anyOf": [
@@ -59,33 +86,6 @@
         },
         {
           "instanceof": "Function"
-        }
-      ]
-    },
-    "config": {
-      "description": "Allows to specify PostCSS Config Path (https://github.com/postcss/postcss-loader#config)",
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "path": {
-              "description": "Allows to specify PostCSS Config Path (https://github.com/postcss/postcss-loader#path)",
-              "type": "string"
-            },
-            "ctx": {
-              "description": "Allows to specify PostCSS Config Context (https://github.com/postcss/postcss-loader#context-ctx)",
-              "type": "object"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Allows to specify the path to the configuration file",
-          "type": "string"
-        },
-        {
-          "description": "Enables/Disables autoloading config",
-          "type": "boolean"
         }
       ]
     },

--- a/src/utils.js
+++ b/src/utils.js
@@ -151,6 +151,7 @@ async function loadConfig(config, context, configPath, loaderContext) {
 
   if (result.filepath) {
     resultConfig.file = result.filepath;
+
     loaderContext.addDependency(result.filepath);
   }
 

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -4,7 +4,7 @@ exports[`validate options should throw an error on the "config" option with "[]"
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.config should be one of these:
    object { path?, ctx? } | string | boolean
-   -> should be {Object} (https://github.com/postcss/postcss-loader#config)
+   -> Allows to specify PostCSS Config Path (https://github.com/postcss/postcss-loader#config)
    Details:
     * options.config should be an object:
       object { path?, ctx? }
@@ -23,131 +23,236 @@ exports[`validate options should throw an error on the "config" option with "{"f
 exports[`validate options should throw an error on the "exec" option with "/test/" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.exec should be a boolean.
-   -> should be {Boolean} (https://github.com/postcss/postcss-loader#exec)"
+   -> Enable PostCSS Parser support in 'CSS-in-JS' (https://github.com/postcss/postcss-loader#exec)"
 `;
 
 exports[`validate options should throw an error on the "exec" option with "[]" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.exec should be a boolean.
-   -> should be {Boolean} (https://github.com/postcss/postcss-loader#exec)"
+   -> Enable PostCSS Parser support in 'CSS-in-JS' (https://github.com/postcss/postcss-loader#exec)"
 `;
 
 exports[`validate options should throw an error on the "exec" option with "{"foo":"bar"}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.exec should be a boolean.
-   -> should be {Boolean} (https://github.com/postcss/postcss-loader#exec)"
+   -> Enable PostCSS Parser support in 'CSS-in-JS' (https://github.com/postcss/postcss-loader#exec)"
 `;
 
 exports[`validate options should throw an error on the "exec" option with "{}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.exec should be a boolean.
-   -> should be {Boolean} (https://github.com/postcss/postcss-loader#exec)"
+   -> Enable PostCSS Parser support in 'CSS-in-JS' (https://github.com/postcss/postcss-loader#exec)"
 `;
 
 exports[`validate options should throw an error on the "exec" option with "1" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.exec should be a boolean.
-   -> should be {Boolean} (https://github.com/postcss/postcss-loader#exec)"
+   -> Enable PostCSS Parser support in 'CSS-in-JS' (https://github.com/postcss/postcss-loader#exec)"
 `;
 
 exports[`validate options should throw an error on the "exec" option with "test" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.exec should be a boolean.
-   -> should be {Boolean} (https://github.com/postcss/postcss-loader#exec)"
+   -> Enable PostCSS Parser support in 'CSS-in-JS' (https://github.com/postcss/postcss-loader#exec)"
 `;
 
-exports[`validate options should throw an error on the "parser" option with "[]" value 1`] = `
+exports[`validate options should throw an error on the "postcssOptions" option with "{"parser":[]}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.parser should be one of these:
-   string | object { … } | function
-   -> should be {String|Object} (https://github.com/postcss/postcss-loader#parser)
+ - options.postcssOptions should be one of these:
+   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   -> Options to pass through to \`Postcss\`.
    Details:
-    * options.parser should be a string.
-    * options.parser should be an object:
-      object { … }
-    * options.parser should be an instance of function."
+    * options.postcssOptions.parser should be one of these:
+      string | object { … } | function
+      -> Allows to specify custom Postcss Parser (https://github.com/postcss/postcss-loader#parser)
+      Details:
+       * options.postcssOptions.parser should be a string.
+       * options.postcssOptions.parser should be an object:
+         object { … }
+       * options.postcssOptions.parser should be an instance of function."
 `;
 
-exports[`validate options should throw an error on the "parser" option with "1" value 1`] = `
+exports[`validate options should throw an error on the "postcssOptions" option with "{"parser":1}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.parser should be one of these:
-   string | object { … } | function
-   -> should be {String|Object} (https://github.com/postcss/postcss-loader#parser)
+ - options.postcssOptions should be one of these:
+   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   -> Options to pass through to \`Postcss\`.
    Details:
-    * options.parser should be a string.
-    * options.parser should be an object:
-      object { … }
-    * options.parser should be an instance of function."
+    * options.postcssOptions.parser should be one of these:
+      string | object { … } | function
+      -> Allows to specify custom Postcss Parser (https://github.com/postcss/postcss-loader#parser)
+      Details:
+       * options.postcssOptions.parser should be a string.
+       * options.postcssOptions.parser should be an object:
+         object { … }
+       * options.postcssOptions.parser should be an instance of function."
 `;
 
-exports[`validate options should throw an error on the "parser" option with "false" value 1`] = `
+exports[`validate options should throw an error on the "postcssOptions" option with "{"parser":true}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.parser should be one of these:
-   string | object { … } | function
-   -> should be {String|Object} (https://github.com/postcss/postcss-loader#parser)
+ - options.postcssOptions should be one of these:
+   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   -> Options to pass through to \`Postcss\`.
    Details:
-    * options.parser should be a string.
-    * options.parser should be an object:
-      object { … }
-    * options.parser should be an instance of function."
+    * options.postcssOptions.parser should be one of these:
+      string | object { … } | function
+      -> Allows to specify custom Postcss Parser (https://github.com/postcss/postcss-loader#parser)
+      Details:
+       * options.postcssOptions.parser should be a string.
+       * options.postcssOptions.parser should be an object:
+         object { … }
+       * options.postcssOptions.parser should be an instance of function."
 `;
 
-exports[`validate options should throw an error on the "parser" option with "true" value 1`] = `
+exports[`validate options should throw an error on the "postcssOptions" option with "{"plugins":"postcss-short"}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.parser should be one of these:
-   string | object { … } | function
-   -> should be {String|Object} (https://github.com/postcss/postcss-loader#parser)
+ - options.postcssOptions should be one of these:
+   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   -> Options to pass through to \`Postcss\`.
    Details:
-    * options.parser should be a string.
-    * options.parser should be an object:
-      object { … }
-    * options.parser should be an instance of function."
+    * options.postcssOptions.plugins should be one of these:
+      [any, ...] | object { … } | function
+      -> Set PostCSS Plugins (https://github.com/postcss/postcss-loader#plugins)
+      Details:
+       * options.postcssOptions.plugins should be an array:
+         [any, ...]
+       * options.postcssOptions.plugins should be an object:
+         object { … }
+       * options.postcssOptions.plugins should be an instance of function."
 `;
 
-exports[`validate options should throw an error on the "plugins" option with "1" value 1`] = `
+exports[`validate options should throw an error on the "postcssOptions" option with "{"plugins":1}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.plugins should be one of these:
-   [any, ...] | object { … } | function
-   -> should be {Array|Object|Function} (https://github.com/postcss/postcss-loader#plugins)
+ - options.postcssOptions should be one of these:
+   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   -> Options to pass through to \`Postcss\`.
    Details:
-    * options.plugins should be an array:
-      [any, ...]
-    * options.plugins should be an object:
-      object { … }
-    * options.plugins should be an instance of function."
+    * options.postcssOptions.plugins should be one of these:
+      [any, ...] | object { … } | function
+      -> Set PostCSS Plugins (https://github.com/postcss/postcss-loader#plugins)
+      Details:
+       * options.postcssOptions.plugins should be an array:
+         [any, ...]
+       * options.postcssOptions.plugins should be an object:
+         object { … }
+       * options.postcssOptions.plugins should be an instance of function."
 `;
 
-exports[`validate options should throw an error on the "plugins" option with "false" value 1`] = `
+exports[`validate options should throw an error on the "postcssOptions" option with "{"plugins":true}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.plugins should be one of these:
-   [any, ...] | object { … } | function
-   -> should be {Array|Object|Function} (https://github.com/postcss/postcss-loader#plugins)
+ - options.postcssOptions should be one of these:
+   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   -> Options to pass through to \`Postcss\`.
    Details:
-    * options.plugins should be an array:
-      [any, ...]
-    * options.plugins should be an object:
-      object { … }
-    * options.plugins should be an instance of function."
+    * options.postcssOptions.plugins should be one of these:
+      [any, ...] | object { … } | function
+      -> Set PostCSS Plugins (https://github.com/postcss/postcss-loader#plugins)
+      Details:
+       * options.postcssOptions.plugins should be an array:
+         [any, ...]
+       * options.postcssOptions.plugins should be an object:
+         object { … }
+       * options.postcssOptions.plugins should be an instance of function."
 `;
 
-exports[`validate options should throw an error on the "plugins" option with "true" value 1`] = `
+exports[`validate options should throw an error on the "postcssOptions" option with "{"stringifier":[]}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.plugins should be one of these:
-   [any, ...] | object { … } | function
-   -> should be {Array|Object|Function} (https://github.com/postcss/postcss-loader#plugins)
+ - options.postcssOptions should be one of these:
+   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   -> Options to pass through to \`Postcss\`.
    Details:
-    * options.plugins should be an array:
-      [any, ...]
-    * options.plugins should be an object:
-      object { … }
-    * options.plugins should be an instance of function."
+    * options.postcssOptions.stringifier should be one of these:
+      string | object { … } | function
+      -> Allows to specify custom Postcss stringifier (https://github.com/postcss/postcss-loader#stringifier)
+      Details:
+       * options.postcssOptions.stringifier should be a string.
+       * options.postcssOptions.stringifier should be an object:
+         object { … }
+       * options.postcssOptions.stringifier should be an instance of function."
+`;
+
+exports[`validate options should throw an error on the "postcssOptions" option with "{"stringifier":1}" value 1`] = `
+"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
+ - options.postcssOptions should be one of these:
+   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   -> Options to pass through to \`Postcss\`.
+   Details:
+    * options.postcssOptions.stringifier should be one of these:
+      string | object { … } | function
+      -> Allows to specify custom Postcss stringifier (https://github.com/postcss/postcss-loader#stringifier)
+      Details:
+       * options.postcssOptions.stringifier should be a string.
+       * options.postcssOptions.stringifier should be an object:
+         object { … }
+       * options.postcssOptions.stringifier should be an instance of function."
+`;
+
+exports[`validate options should throw an error on the "postcssOptions" option with "{"stringifier":true}" value 1`] = `
+"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
+ - options.postcssOptions should be one of these:
+   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   -> Options to pass through to \`Postcss\`.
+   Details:
+    * options.postcssOptions.stringifier should be one of these:
+      string | object { … } | function
+      -> Allows to specify custom Postcss stringifier (https://github.com/postcss/postcss-loader#stringifier)
+      Details:
+       * options.postcssOptions.stringifier should be a string.
+       * options.postcssOptions.stringifier should be an object:
+         object { … }
+       * options.postcssOptions.stringifier should be an instance of function."
+`;
+
+exports[`validate options should throw an error on the "postcssOptions" option with "{"syntax":[]}" value 1`] = `
+"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
+ - options.postcssOptions should be one of these:
+   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   -> Options to pass through to \`Postcss\`.
+   Details:
+    * options.postcssOptions.syntax should be one of these:
+      string | object { … }
+      -> Allows to specify custom Postcss Syntax (https://github.com/postcss/postcss-loader#syntax)
+      Details:
+       * options.postcssOptions.syntax should be a string.
+       * options.postcssOptions.syntax should be an object:
+         object { … }"
+`;
+
+exports[`validate options should throw an error on the "postcssOptions" option with "{"syntax":1}" value 1`] = `
+"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
+ - options.postcssOptions should be one of these:
+   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   -> Options to pass through to \`Postcss\`.
+   Details:
+    * options.postcssOptions.syntax should be one of these:
+      string | object { … }
+      -> Allows to specify custom Postcss Syntax (https://github.com/postcss/postcss-loader#syntax)
+      Details:
+       * options.postcssOptions.syntax should be a string.
+       * options.postcssOptions.syntax should be an object:
+         object { … }"
+`;
+
+exports[`validate options should throw an error on the "postcssOptions" option with "{"syntax":true}" value 1`] = `
+"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
+ - options.postcssOptions should be one of these:
+   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   -> Options to pass through to \`Postcss\`.
+   Details:
+    * options.postcssOptions.syntax should be one of these:
+      string | object { … }
+      -> Allows to specify custom Postcss Syntax (https://github.com/postcss/postcss-loader#syntax)
+      Details:
+       * options.postcssOptions.syntax should be a string.
+       * options.postcssOptions.syntax should be an object:
+         object { … }"
 `;
 
 exports[`validate options should throw an error on the "sourceMap" option with "/test/" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.sourceMap should be one of these:
    string | boolean
-   -> should be {String|Boolean} (https://github.com/postcss/postcss-loader#sourcemap)
+   -> Enables/Disables generation of source maps (https://github.com/postcss/postcss-loader#sourcemap)
    Details:
     * options.sourceMap should be a string.
     * options.sourceMap should be a boolean."
@@ -157,7 +262,7 @@ exports[`validate options should throw an error on the "sourceMap" option with "
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.sourceMap should be one of these:
    string | boolean
-   -> should be {String|Boolean} (https://github.com/postcss/postcss-loader#sourcemap)
+   -> Enables/Disables generation of source maps (https://github.com/postcss/postcss-loader#sourcemap)
    Details:
     * options.sourceMap should be a string.
     * options.sourceMap should be a boolean."
@@ -167,7 +272,7 @@ exports[`validate options should throw an error on the "sourceMap" option with "
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.sourceMap should be one of these:
    string | boolean
-   -> should be {String|Boolean} (https://github.com/postcss/postcss-loader#sourcemap)
+   -> Enables/Disables generation of source maps (https://github.com/postcss/postcss-loader#sourcemap)
    Details:
     * options.sourceMap should be a string.
     * options.sourceMap should be a boolean."
@@ -177,100 +282,8 @@ exports[`validate options should throw an error on the "sourceMap" option with "
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.sourceMap should be one of these:
    string | boolean
-   -> should be {String|Boolean} (https://github.com/postcss/postcss-loader#sourcemap)
+   -> Enables/Disables generation of source maps (https://github.com/postcss/postcss-loader#sourcemap)
    Details:
     * options.sourceMap should be a string.
     * options.sourceMap should be a boolean."
-`;
-
-exports[`validate options should throw an error on the "stringifier" option with "[]" value 1`] = `
-"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.stringifier should be one of these:
-   string | object { … } | function
-   -> should be {String|Object} (https://github.com/postcss/postcss-loader#stringifier)
-   Details:
-    * options.stringifier should be a string.
-    * options.stringifier should be an object:
-      object { … }
-    * options.stringifier should be an instance of function."
-`;
-
-exports[`validate options should throw an error on the "stringifier" option with "1" value 1`] = `
-"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.stringifier should be one of these:
-   string | object { … } | function
-   -> should be {String|Object} (https://github.com/postcss/postcss-loader#stringifier)
-   Details:
-    * options.stringifier should be a string.
-    * options.stringifier should be an object:
-      object { … }
-    * options.stringifier should be an instance of function."
-`;
-
-exports[`validate options should throw an error on the "stringifier" option with "false" value 1`] = `
-"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.stringifier should be one of these:
-   string | object { … } | function
-   -> should be {String|Object} (https://github.com/postcss/postcss-loader#stringifier)
-   Details:
-    * options.stringifier should be a string.
-    * options.stringifier should be an object:
-      object { … }
-    * options.stringifier should be an instance of function."
-`;
-
-exports[`validate options should throw an error on the "stringifier" option with "true" value 1`] = `
-"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.stringifier should be one of these:
-   string | object { … } | function
-   -> should be {String|Object} (https://github.com/postcss/postcss-loader#stringifier)
-   Details:
-    * options.stringifier should be a string.
-    * options.stringifier should be an object:
-      object { … }
-    * options.stringifier should be an instance of function."
-`;
-
-exports[`validate options should throw an error on the "syntax" option with "[]" value 1`] = `
-"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.syntax should be one of these:
-   string | object { … }
-   -> should be {String|Object} (https://github.com/postcss/postcss-loader#syntax)
-   Details:
-    * options.syntax should be a string.
-    * options.syntax should be an object:
-      object { … }"
-`;
-
-exports[`validate options should throw an error on the "syntax" option with "1" value 1`] = `
-"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.syntax should be one of these:
-   string | object { … }
-   -> should be {String|Object} (https://github.com/postcss/postcss-loader#syntax)
-   Details:
-    * options.syntax should be a string.
-    * options.syntax should be an object:
-      object { … }"
-`;
-
-exports[`validate options should throw an error on the "syntax" option with "false" value 1`] = `
-"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.syntax should be one of these:
-   string | object { … }
-   -> should be {String|Object} (https://github.com/postcss/postcss-loader#syntax)
-   Details:
-    * options.syntax should be a string.
-    * options.syntax should be an object:
-      object { … }"
-`;
-
-exports[`validate options should throw an error on the "syntax" option with "true" value 1`] = `
-"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.syntax should be one of these:
-   string | object { … }
-   -> should be {String|Object} (https://github.com/postcss/postcss-loader#syntax)
-   Details:
-    * options.syntax should be a string.
-    * options.syntax should be an object:
-      object { … }"
 `;

--- a/test/__snapshots__/validate-options.test.js.snap
+++ b/test/__snapshots__/validate-options.test.js.snap
@@ -1,25 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`validate options should throw an error on the "config" option with "[]" value 1`] = `
-"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.config should be one of these:
-   object { path?, ctx? } | string | boolean
-   -> Allows to specify PostCSS Config Path (https://github.com/postcss/postcss-loader#config)
-   Details:
-    * options.config should be an object:
-      object { path?, ctx? }
-    * options.config should be a string.
-      -> Allows to specify the path to the configuration file
-    * options.config should be a boolean.
-      -> Enables/Disables autoloading config"
-`;
-
-exports[`validate options should throw an error on the "config" option with "{"foo":"bar"}" value 1`] = `
-"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
- - options.config has an unknown property 'foo'. These properties are valid:
-   object { path?, ctx? }"
-`;
-
 exports[`validate options should throw an error on the "exec" option with "/test/" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.exec should be a boolean.
@@ -56,10 +36,28 @@ exports[`validate options should throw an error on the "exec" option with "test"
    -> Enable PostCSS Parser support in 'CSS-in-JS' (https://github.com/postcss/postcss-loader#exec)"
 `;
 
+exports[`validate options should throw an error on the "postcssOptions" option with "{"config":[]}" value 1`] = `
+"Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
+ - options.postcssOptions should be one of these:
+   object { config?, parser?, syntax?, stringifier?, plugins?, … } | function
+   -> Options to pass through to \`Postcss\`.
+   Details:
+    * options.postcssOptions.config should be one of these:
+      object { path?, ctx? } | string | boolean
+      -> Allows to specify PostCSS Config Path (https://github.com/postcss/postcss-loader#config)
+      Details:
+       * options.postcssOptions.config should be an object:
+         object { path?, ctx? }
+       * options.postcssOptions.config should be a string.
+         -> Allows to specify the path to the configuration file
+       * options.postcssOptions.config should be a boolean.
+         -> Enables/Disables autoloading config"
+`;
+
 exports[`validate options should throw an error on the "postcssOptions" option with "{"parser":[]}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.postcssOptions should be one of these:
-   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   object { config?, parser?, syntax?, stringifier?, plugins?, … } | function
    -> Options to pass through to \`Postcss\`.
    Details:
     * options.postcssOptions.parser should be one of these:
@@ -75,7 +73,7 @@ exports[`validate options should throw an error on the "postcssOptions" option w
 exports[`validate options should throw an error on the "postcssOptions" option with "{"parser":1}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.postcssOptions should be one of these:
-   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   object { config?, parser?, syntax?, stringifier?, plugins?, … } | function
    -> Options to pass through to \`Postcss\`.
    Details:
     * options.postcssOptions.parser should be one of these:
@@ -91,7 +89,7 @@ exports[`validate options should throw an error on the "postcssOptions" option w
 exports[`validate options should throw an error on the "postcssOptions" option with "{"parser":true}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.postcssOptions should be one of these:
-   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   object { config?, parser?, syntax?, stringifier?, plugins?, … } | function
    -> Options to pass through to \`Postcss\`.
    Details:
     * options.postcssOptions.parser should be one of these:
@@ -107,7 +105,7 @@ exports[`validate options should throw an error on the "postcssOptions" option w
 exports[`validate options should throw an error on the "postcssOptions" option with "{"plugins":"postcss-short"}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.postcssOptions should be one of these:
-   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   object { config?, parser?, syntax?, stringifier?, plugins?, … } | function
    -> Options to pass through to \`Postcss\`.
    Details:
     * options.postcssOptions.plugins should be one of these:
@@ -124,7 +122,7 @@ exports[`validate options should throw an error on the "postcssOptions" option w
 exports[`validate options should throw an error on the "postcssOptions" option with "{"plugins":1}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.postcssOptions should be one of these:
-   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   object { config?, parser?, syntax?, stringifier?, plugins?, … } | function
    -> Options to pass through to \`Postcss\`.
    Details:
     * options.postcssOptions.plugins should be one of these:
@@ -141,7 +139,7 @@ exports[`validate options should throw an error on the "postcssOptions" option w
 exports[`validate options should throw an error on the "postcssOptions" option with "{"plugins":true}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.postcssOptions should be one of these:
-   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   object { config?, parser?, syntax?, stringifier?, plugins?, … } | function
    -> Options to pass through to \`Postcss\`.
    Details:
     * options.postcssOptions.plugins should be one of these:
@@ -158,7 +156,7 @@ exports[`validate options should throw an error on the "postcssOptions" option w
 exports[`validate options should throw an error on the "postcssOptions" option with "{"stringifier":[]}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.postcssOptions should be one of these:
-   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   object { config?, parser?, syntax?, stringifier?, plugins?, … } | function
    -> Options to pass through to \`Postcss\`.
    Details:
     * options.postcssOptions.stringifier should be one of these:
@@ -174,7 +172,7 @@ exports[`validate options should throw an error on the "postcssOptions" option w
 exports[`validate options should throw an error on the "postcssOptions" option with "{"stringifier":1}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.postcssOptions should be one of these:
-   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   object { config?, parser?, syntax?, stringifier?, plugins?, … } | function
    -> Options to pass through to \`Postcss\`.
    Details:
     * options.postcssOptions.stringifier should be one of these:
@@ -190,7 +188,7 @@ exports[`validate options should throw an error on the "postcssOptions" option w
 exports[`validate options should throw an error on the "postcssOptions" option with "{"stringifier":true}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.postcssOptions should be one of these:
-   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   object { config?, parser?, syntax?, stringifier?, plugins?, … } | function
    -> Options to pass through to \`Postcss\`.
    Details:
     * options.postcssOptions.stringifier should be one of these:
@@ -206,7 +204,7 @@ exports[`validate options should throw an error on the "postcssOptions" option w
 exports[`validate options should throw an error on the "postcssOptions" option with "{"syntax":[]}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.postcssOptions should be one of these:
-   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   object { config?, parser?, syntax?, stringifier?, plugins?, … } | function
    -> Options to pass through to \`Postcss\`.
    Details:
     * options.postcssOptions.syntax should be one of these:
@@ -221,7 +219,7 @@ exports[`validate options should throw an error on the "postcssOptions" option w
 exports[`validate options should throw an error on the "postcssOptions" option with "{"syntax":1}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.postcssOptions should be one of these:
-   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   object { config?, parser?, syntax?, stringifier?, plugins?, … } | function
    -> Options to pass through to \`Postcss\`.
    Details:
     * options.postcssOptions.syntax should be one of these:
@@ -236,7 +234,7 @@ exports[`validate options should throw an error on the "postcssOptions" option w
 exports[`validate options should throw an error on the "postcssOptions" option with "{"syntax":true}" value 1`] = `
 "Invalid options object. PostCSS Loader has been initialized using an options object that does not match the API schema.
  - options.postcssOptions should be one of these:
-   object { parser?, syntax?, stringifier?, plugins?, … } | function
+   object { config?, parser?, syntax?, stringifier?, plugins?, … } | function
    -> Options to pass through to \`Postcss\`.
    Details:
     * options.postcssOptions.syntax should be one of these:

--- a/test/config-autoload.test.js
+++ b/test/config-autoload.test.js
@@ -20,14 +20,10 @@ describe('config-autoload', () => {
 
   it('.postcssrc - {Object} - Load Config', async () => {
     const expected = (config) => {
-      expect(config.postcssOptions.map).toEqual(false);
-      expect(config.postcssOptions.from).toEqual(
-        './test/rc/fixtures/index.css'
-      );
-      expect(config.postcssOptions.to).toEqual('./test/rc/expect/index.css');
-
-      expect(Object.keys(config.postcssOptions.plugins).length).toEqual(3);
-
+      expect(config.map).toEqual(false);
+      expect(config.from).toEqual('./test/rc/fixtures/index.css');
+      expect(config.to).toEqual('./test/rc/expect/index.css');
+      expect(Object.keys(config.plugins).length).toEqual(3);
       expect(config.file).toEqual(
         path.resolve(testDirectory, 'rc', '.postcssrc')
       );
@@ -45,16 +41,10 @@ describe('config-autoload', () => {
 
   it('postcss.config.js - {Object} - Load Config', async () => {
     const expected = (config) => {
-      expect(config.postcssOptions.map).toEqual(false);
-      expect(config.postcssOptions.from).toEqual(
-        './test/js/object/fixtures/index.css'
-      );
-      expect(config.postcssOptions.to).toEqual(
-        './test/js/object/expect/index.css'
-      );
-
-      expect(Object.keys(config.postcssOptions.plugins).length).toEqual(3);
-
+      expect(config.map).toEqual(false);
+      expect(config.from).toEqual('./test/js/object/fixtures/index.css');
+      expect(config.to).toEqual('./test/js/object/expect/index.css');
+      expect(Object.keys(config.plugins).length).toEqual(3);
       expect(config.file).toEqual(
         path.resolve(testDirectory, 'js/object', 'postcss.config.js')
       );
@@ -72,16 +62,10 @@ describe('config-autoload', () => {
 
   it('postcss.config.js - {Array} - Load Config', async () => {
     const expected = (config) => {
-      expect(config.postcssOptions.map).toEqual(false);
-      expect(config.postcssOptions.from).toEqual(
-        './test/js/array/fixtures/index.css'
-      );
-      expect(config.postcssOptions.to).toEqual(
-        './test/js/array/expect/index.css'
-      );
-
-      expect(Object.keys(config.postcssOptions.plugins).length).toEqual(3);
-
+      expect(config.map).toEqual(false);
+      expect(config.from).toEqual('./test/js/array/fixtures/index.css');
+      expect(config.to).toEqual('./test/js/array/expect/index.css');
+      expect(Object.keys(config.plugins).length).toEqual(3);
       expect(config.file).toEqual(
         path.resolve(testDirectory, 'js/array', 'postcss.config.js')
       );
@@ -99,15 +83,12 @@ describe('config-autoload', () => {
 
   it('package.json - {Object} - Load Config', async () => {
     const expected = (config) => {
-      expect(config.postcssOptions.parser).toEqual(false);
-      expect(config.postcssOptions.syntax).toEqual(false);
-      expect(config.postcssOptions.map).toEqual(false);
-      expect(config.postcssOptions.from).toEqual(
-        './test/pkg/fixtures/index.css'
-      );
-      expect(config.postcssOptions.to).toEqual('./test/pkg/expect/index.css');
-      expect(Object.keys(config.postcssOptions.plugins).length).toEqual(3);
-
+      expect(config.parser).toEqual(false);
+      expect(config.syntax).toEqual(false);
+      expect(config.map).toEqual(false);
+      expect(config.from).toEqual('./test/pkg/fixtures/index.css');
+      expect(config.to).toEqual('./test/pkg/expect/index.css');
+      expect(Object.keys(config.plugins).length).toEqual(3);
       expect(config.file).toEqual(
         path.resolve(testDirectory, 'pkg', 'package.json')
       );

--- a/test/config-autoload.test.js
+++ b/test/config-autoload.test.js
@@ -20,11 +20,13 @@ describe('config-autoload', () => {
 
   it('.postcssrc - {Object} - Load Config', async () => {
     const expected = (config) => {
-      expect(config.map).toEqual(false);
-      expect(config.from).toEqual('./test/rc/fixtures/index.css');
-      expect(config.to).toEqual('./test/rc/expect/index.css');
+      expect(config.postcssOptions.map).toEqual(false);
+      expect(config.postcssOptions.from).toEqual(
+        './test/rc/fixtures/index.css'
+      );
+      expect(config.postcssOptions.to).toEqual('./test/rc/expect/index.css');
 
-      expect(Object.keys(config.plugins).length).toEqual(3);
+      expect(Object.keys(config.postcssOptions.plugins).length).toEqual(3);
 
       expect(config.file).toEqual(
         path.resolve(testDirectory, 'rc', '.postcssrc')
@@ -43,11 +45,15 @@ describe('config-autoload', () => {
 
   it('postcss.config.js - {Object} - Load Config', async () => {
     const expected = (config) => {
-      expect(config.map).toEqual(false);
-      expect(config.from).toEqual('./test/js/object/fixtures/index.css');
-      expect(config.to).toEqual('./test/js/object/expect/index.css');
+      expect(config.postcssOptions.map).toEqual(false);
+      expect(config.postcssOptions.from).toEqual(
+        './test/js/object/fixtures/index.css'
+      );
+      expect(config.postcssOptions.to).toEqual(
+        './test/js/object/expect/index.css'
+      );
 
-      expect(Object.keys(config.plugins).length).toEqual(3);
+      expect(Object.keys(config.postcssOptions.plugins).length).toEqual(3);
 
       expect(config.file).toEqual(
         path.resolve(testDirectory, 'js/object', 'postcss.config.js')
@@ -66,11 +72,15 @@ describe('config-autoload', () => {
 
   it('postcss.config.js - {Array} - Load Config', async () => {
     const expected = (config) => {
-      expect(config.map).toEqual(false);
-      expect(config.from).toEqual('./test/js/array/fixtures/index.css');
-      expect(config.to).toEqual('./test/js/array/expect/index.css');
+      expect(config.postcssOptions.map).toEqual(false);
+      expect(config.postcssOptions.from).toEqual(
+        './test/js/array/fixtures/index.css'
+      );
+      expect(config.postcssOptions.to).toEqual(
+        './test/js/array/expect/index.css'
+      );
 
-      expect(Object.keys(config.plugins).length).toEqual(3);
+      expect(Object.keys(config.postcssOptions.plugins).length).toEqual(3);
 
       expect(config.file).toEqual(
         path.resolve(testDirectory, 'js/array', 'postcss.config.js')
@@ -89,12 +99,14 @@ describe('config-autoload', () => {
 
   it('package.json - {Object} - Load Config', async () => {
     const expected = (config) => {
-      expect(config.parser).toEqual(false);
-      expect(config.syntax).toEqual(false);
-      expect(config.map).toEqual(false);
-      expect(config.from).toEqual('./test/pkg/fixtures/index.css');
-      expect(config.to).toEqual('./test/pkg/expect/index.css');
-      expect(Object.keys(config.plugins).length).toEqual(3);
+      expect(config.postcssOptions.parser).toEqual(false);
+      expect(config.postcssOptions.syntax).toEqual(false);
+      expect(config.postcssOptions.map).toEqual(false);
+      expect(config.postcssOptions.from).toEqual(
+        './test/pkg/fixtures/index.css'
+      );
+      expect(config.postcssOptions.to).toEqual('./test/pkg/expect/index.css');
+      expect(Object.keys(config.postcssOptions.plugins).length).toEqual(3);
 
       expect(config.file).toEqual(
         path.resolve(testDirectory, 'pkg', 'package.json')

--- a/test/fixtures/config-autoload/err/options/parser/.postcssrc.js
+++ b/test/fixtures/config-autoload/err/options/parser/.postcssrc.js
@@ -1,5 +1,5 @@
-module.exports = function (ctx) {
+module.exports = function () {
   return {
     parser: 'postcss-parser'
   }
-}
+};

--- a/test/fixtures/config-autoload/err/options/stringifier/.postcssrc.js
+++ b/test/fixtures/config-autoload/err/options/stringifier/.postcssrc.js
@@ -1,5 +1,5 @@
-module.exports = function (ctx) {
+module.exports = function () {
   return {
     stringifier: 'postcss-stringifier'
   }
-}
+};

--- a/test/fixtures/config-autoload/err/options/syntax/.postcssrc.js
+++ b/test/fixtures/config-autoload/err/options/syntax/.postcssrc.js
@@ -1,5 +1,5 @@
-module.exports = function (ctx) {
+module.exports = function () {
   return {
     syntax: 'postcss-syntax'
   }
-}
+};

--- a/test/fixtures/config-autoload/err/plugins/.postcssrc.js
+++ b/test/fixtures/config-autoload/err/plugins/.postcssrc.js
@@ -1,7 +1,7 @@
-module.exports = function (ctx) {
+module.exports = function () {
   return {
     plugins: [
       require('./plugin')
     ]
   }
-}
+};

--- a/test/fixtures/config-autoload/err/plugins/array/.postcssrc.js
+++ b/test/fixtures/config-autoload/err/plugins/array/.postcssrc.js
@@ -1,7 +1,7 @@
-module.exports = function (ctx) {
+module.exports = function () {
   return {
     plugins: [
       require('postcss-plugin')
     ]
   }
-}
+};

--- a/test/fixtures/config-autoload/err/plugins/array/options/.postcssrc.js
+++ b/test/fixtures/config-autoload/err/plugins/array/options/.postcssrc.js
@@ -1,7 +1,7 @@
-module.exports = function (ctx) {
+module.exports = function () {
   return {
     plugins: [
       require('postcss-plugin')
     ]
   }
-}
+};

--- a/test/fixtures/config-autoload/err/plugins/object/.postcssrc.js
+++ b/test/fixtures/config-autoload/err/plugins/object/.postcssrc.js
@@ -1,7 +1,7 @@
-module.exports = function (ctx) {
+module.exports = function () {
   return {
     plugins: {
       'postcss-plugin': {}
     }
   }
-}
+};

--- a/test/fixtures/config-autoload/err/plugins/object/options/.postcssrc.js
+++ b/test/fixtures/config-autoload/err/plugins/object/options/.postcssrc.js
@@ -1,7 +1,7 @@
-module.exports = function (ctx) {
+module.exports = function () {
   return {
     plugins: {
       'postcss-plugin': { option: true }
     }
   }
-}
+};

--- a/test/fixtures/config-autoload/err/plugins/plugin.js
+++ b/test/fixtures/config-autoload/err/plugins/plugin.js
@@ -1,1 +1,1 @@
-module.exports = 'Invalid Plugin'
+module.exports = 'Invalid Plugin';

--- a/test/fixtures/config-autoload/js/array/postcss.config.js
+++ b/test/fixtures/config-autoload/js/array/postcss.config.js
@@ -1,14 +1,16 @@
 module.exports = function (ctx) {
   return {
-    parser: ctx.parser ? 'sugarss' : false,
-    syntax: ctx.syntax ? 'sugarss' : false,
-    map: ctx.map ? 'inline' : false,
-    from: './test/js/array/fixtures/index.css',
-    to: './test/js/array/expect/index.css',
-    plugins: [
-      require('postcss-import')(),
-      require('postcss-nested')(),
-      ctx.env === 'production' ? require('cssnano')() : false
-    ]
+    postcssOptions: {
+      parser: ctx.parser ? 'sugarss' : false,
+      syntax: ctx.syntax ? 'sugarss' : false,
+      map: ctx.map ? 'inline' : false,
+      from: './test/js/array/fixtures/index.css',
+      to: './test/js/array/expect/index.css',
+      plugins: [
+        require('postcss-import')(),
+        require('postcss-nested')(),
+        ctx.env === 'production' ? require('cssnano')() : false
+      ]
+    }
   }
 }

--- a/test/fixtures/config-autoload/js/array/postcss.config.js
+++ b/test/fixtures/config-autoload/js/array/postcss.config.js
@@ -1,16 +1,14 @@
 module.exports = function (ctx) {
   return {
-    postcssOptions: {
-      parser: ctx.parser ? 'sugarss' : false,
-      syntax: ctx.syntax ? 'sugarss' : false,
-      map: ctx.map ? 'inline' : false,
-      from: './test/js/array/fixtures/index.css',
-      to: './test/js/array/expect/index.css',
-      plugins: [
-        require('postcss-import')(),
-        require('postcss-nested')(),
-        ctx.env === 'production' ? require('cssnano')() : false
-      ]
-    }
+    parser: ctx.parser ? 'sugarss' : false,
+    syntax: ctx.syntax ? 'sugarss' : false,
+    map: ctx.map ? 'inline' : false,
+    from: './test/js/array/fixtures/index.css',
+    to: './test/js/array/expect/index.css',
+    plugins: [
+      require('postcss-import')(),
+      require('postcss-nested')(),
+      ctx.env === 'production' ? require('cssnano')() : false
+    ]
   }
-}
+};

--- a/test/fixtures/config-autoload/js/object/postcss.config.js
+++ b/test/fixtures/config-autoload/js/object/postcss.config.js
@@ -11,4 +11,4 @@ module.exports = function (ctx) {
       'cssnano': ctx.env === 'production' ? {} : false
     }
   }
-}
+};

--- a/test/fixtures/config-autoload/js/object/postcss.config.js
+++ b/test/fixtures/config-autoload/js/object/postcss.config.js
@@ -8,7 +8,7 @@ module.exports = function (ctx) {
     plugins: {
       'postcss-import': {},
       'postcss-nested': {},
-      'cssnano': ctx.env === 'production' ? {} : false,
+      'cssnano': ctx.env === 'production' ? {} : false
     }
   }
 }

--- a/test/fixtures/config-autoload/pkg/package.json
+++ b/test/fixtures/config-autoload/pkg/package.json
@@ -2,15 +2,17 @@
   "name": "postcss-config",
   "version": "1.0.0",
   "postcss": {
-    "parser": false,
-    "syntax": false,
-    "map": false,
-    "from": "./test/pkg/fixtures/index.css",
-    "to": "./test/pkg/expect/index.css",
-    "plugins": {
-      "postcss-import": {},
-      "postcss-nested": {},
-      "cssnano": false
+    "postcssOptions": {
+      "parser": false,
+      "syntax": false,
+      "map": false,
+      "from": "./test/pkg/fixtures/index.css",
+      "to": "./test/pkg/expect/index.css",
+      "plugins": {
+        "postcss-import": {},
+        "postcss-nested": {},
+        "cssnano": false
+      }
     }
   }
 }

--- a/test/fixtures/config-autoload/pkg/package.json
+++ b/test/fixtures/config-autoload/pkg/package.json
@@ -2,17 +2,15 @@
   "name": "postcss-config",
   "version": "1.0.0",
   "postcss": {
-    "postcssOptions": {
-      "parser": false,
-      "syntax": false,
-      "map": false,
-      "from": "./test/pkg/fixtures/index.css",
-      "to": "./test/pkg/expect/index.css",
-      "plugins": {
-        "postcss-import": {},
-        "postcss-nested": {},
-        "cssnano": false
-      }
+    "parser": false,
+    "syntax": false,
+    "map": false,
+    "from": "./test/pkg/fixtures/index.css",
+    "to": "./test/pkg/expect/index.css",
+    "plugins": {
+      "postcss-import": {},
+      "postcss-nested": {},
+      "cssnano": false
     }
   }
 }

--- a/test/fixtures/config-autoload/rc/.postcssrc
+++ b/test/fixtures/config-autoload/rc/.postcssrc
@@ -1,12 +1,14 @@
 {
-  "parser": "sugarss",
-  "syntax": "sugarss",
-  "map": false,
-  "from": "./test/rc/fixtures/index.css",
-  "to": "./test/rc/expect/index.css",
-  "plugins": {
-    "postcss-import": {},
-    "postcss-nested": {},
-    "cssnano": false
+  "postcssOptions": {
+    "parser": "sugarss",
+    "syntax": "sugarss",
+    "map": false,
+    "from": "./test/rc/fixtures/index.css",
+    "to": "./test/rc/expect/index.css",
+    "plugins": {
+      "postcss-import": {},
+      "postcss-nested": {},
+      "cssnano": false
+    }
   }
 }

--- a/test/fixtures/config-autoload/rc/.postcssrc
+++ b/test/fixtures/config-autoload/rc/.postcssrc
@@ -1,14 +1,12 @@
 {
-  "postcssOptions": {
-    "parser": "sugarss",
-    "syntax": "sugarss",
-    "map": false,
-    "from": "./test/rc/fixtures/index.css",
-    "to": "./test/rc/expect/index.css",
-    "plugins": {
-      "postcss-import": {},
-      "postcss-nested": {},
-      "cssnano": false
-    }
+  "parser": "sugarss",
+  "syntax": "sugarss",
+  "map": false,
+  "from": "./test/rc/fixtures/index.css",
+  "to": "./test/rc/expect/index.css",
+  "plugins": {
+    "postcss-import": {},
+    "postcss-nested": {},
+    "cssnano": false
   }
 }

--- a/test/fixtures/config-scope/config/context/postcss.config.js
+++ b/test/fixtures/config-scope/config/context/postcss.config.js
@@ -1,7 +1,5 @@
 module.exports = (ctx) => ({
-  postcssOptions: {
-    plugins: [
-      require('./plugin')(ctx)
-    ]
-  },
-})
+  plugins: [
+    require('./plugin')(ctx)
+  ]
+});

--- a/test/fixtures/config-scope/config/context/postcss.config.js
+++ b/test/fixtures/config-scope/config/context/postcss.config.js
@@ -1,5 +1,7 @@
 module.exports = (ctx) => ({
-  plugins: [
-    require('./plugin')(ctx)
-  ]
+  postcssOptions: {
+    plugins: [
+      require('./plugin')(ctx)
+    ]
+  },
 })

--- a/test/fixtures/config-scope/config/plugin.js
+++ b/test/fixtures/config-scope/config/plugin.js
@@ -1,9 +1,9 @@
-'use strict'
+'use strict';
 
-const postcss = require('postcss')
+const postcss = require('postcss');
 
 module.exports = postcss.plugin('plugin', (options) => {
-  options = Object.assign({ alpha: '1.0' }, options)
+  options = Object.assign({ alpha: '1.0' }, options);
 
   return (css, result) => {
     css.walkDecls((decl) => {
@@ -12,4 +12,4 @@ module.exports = postcss.plugin('plugin', (options) => {
       }
     })
   }
-})
+});

--- a/test/fixtures/config-scope/config/postcss.config.js
+++ b/test/fixtures/config-scope/config/postcss.config.js
@@ -1,7 +1,6 @@
 module.exports = (ctx) => ({
-  postcssOptions: {
-    plugins: [
-      ctx.options.plugin ? require('./plugin')() : false
-    ]
-  },
-})
+  plugins: [
+    ctx.options.plugin ? require('./plugin')() : false
+  ]
+});
+

--- a/test/fixtures/config-scope/config/postcss.config.js
+++ b/test/fixtures/config-scope/config/postcss.config.js
@@ -1,5 +1,7 @@
 module.exports = (ctx) => ({
-  plugins: [
-    ctx.options.plugin ? require('./plugin')() : false
-  ]
+  postcssOptions: {
+    plugins: [
+      ctx.options.plugin ? require('./plugin')() : false
+    ]
+  },
 })

--- a/test/fixtures/config-scope/css/custom.config.js
+++ b/test/fixtures/config-scope/css/custom.config.js
@@ -1,7 +1,6 @@
 module.exports = {
-  postcssOptions: {
-    plugins: [
-      require('../config/plugin')()
-    ]
-  }
-}
+  plugins: [
+    require('../config/plugin')()
+  ]
+};
+

--- a/test/fixtures/config-scope/css/custom.config.js
+++ b/test/fixtures/config-scope/css/custom.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  plugins: [
-    require('../config/plugin')()
-  ]
+  postcssOptions: {
+    plugins: [
+      require('../config/plugin')()
+    ]
+  }
 }

--- a/test/fixtures/config-scope/css/plugins.config.js
+++ b/test/fixtures/config-scope/css/plugins.config.js
@@ -4,4 +4,4 @@ module.exports = {
     'postcss-import': {},
     'postcss-nested': {},
   }
-}
+};

--- a/test/fixtures/config-scope/postcss.config.js
+++ b/test/fixtures/config-scope/postcss.config.js
@@ -1,7 +1,6 @@
 module.exports = {
-  postcssOptions: {
-    plugins: [
-      require('./config/plugin')()
-    ]
-  },
-}
+  plugins: [
+    require('./config/plugin')()
+  ]
+};
+

--- a/test/fixtures/config-scope/postcss.config.js
+++ b/test/fixtures/config-scope/postcss.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  plugins: [
-    require('./config/plugin')()
-  ]
+  postcssOptions: {
+    plugins: [
+      require('./config/plugin')()
+    ]
+  },
 }

--- a/test/fixtures/css/index.js
+++ b/test/fixtures/css/index.js
@@ -1,3 +1,3 @@
-import style from './style.css'
+import style from './style.css';
 
-export default style
+export default style;

--- a/test/fixtures/css/index2.js
+++ b/test/fixtures/css/index2.js
@@ -1,3 +1,3 @@
-import style from './style2.css'
+import style from './style2.css';
 
-export default style
+export default style;

--- a/test/fixtures/css/plugins.config.js
+++ b/test/fixtures/css/plugins.config.js
@@ -1,7 +1,9 @@
 module.exports = {
-  plugins: {
-    'postcss-short': { prefix: 'x' },
-    'postcss-import': {},
-    'postcss-nested': {},
+  postcssOptions: {
+    plugins: {
+      'postcss-short': { prefix: 'x' },
+      'postcss-import': {},
+      'postcss-nested': {},
+    }
   }
 }

--- a/test/fixtures/css/plugins.config.js
+++ b/test/fixtures/css/plugins.config.js
@@ -1,9 +1,7 @@
 module.exports = {
-  postcssOptions: {
-    plugins: {
-      'postcss-short': { prefix: 'x' },
-      'postcss-import': {},
-      'postcss-nested': {},
-    }
+  plugins: {
+    'postcss-short': { prefix: 'x' },
+    'postcss-import': {},
+    'postcss-nested': {},
   }
-}
+};

--- a/test/fixtures/jss/exec/index.js
+++ b/test/fixtures/jss/exec/index.js
@@ -1,3 +1,3 @@
-import style from './style.exec.js'
+import style from './style.exec.js';
 
-export default style
+export default style;

--- a/test/fixtures/jss/exec/style.exec.js
+++ b/test/fixtures/jss/exec/style.exec.js
@@ -1,11 +1,11 @@
-'use strict'
+'use strict';
 
-const postcssJS = require('postcss-js')
+const postcssJS = require('postcss-js');
 
 const style = {
   a: {
     color: 'green'
   }
-}
+};
 
-module.exports = postcssJS.parse(style)
+module.exports = postcssJS.parse(style);

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -11,7 +11,9 @@ import {
 describe('loader', () => {
   it('should work', async () => {
     const compiler = getCompiler('./css/index.js', {
-      plugins: [],
+      postcssOptions: {
+        plugins: [],
+      },
       config: false,
     });
     const stats = await compile(compiler);
@@ -33,7 +35,9 @@ describe('loader', () => {
     const postcssPlugin = postcss.plugin('postcss-plugin', plugin);
 
     const compiler = getCompiler('./css/index.js', {
-      plugins: [postcssPlugin()],
+      postcssOptions: {
+        plugins: [postcssPlugin()],
+      },
       config: false,
     });
     const stats = await compile(compiler);
@@ -47,7 +51,9 @@ describe('loader', () => {
 
   it('should emit Syntax Error', async () => {
     const compiler = getCompiler('./css/index.js', {
-      parser: 'sugarss',
+      postcssOptions: {
+        parser: 'sugarss',
+      },
       config: false,
     });
     const stats = await compile(compiler);
@@ -69,7 +75,9 @@ describe('loader', () => {
     const postcssPlugin = postcss.plugin('postcss-assets', plugin);
 
     const compiler = getCompiler('./css/index.js', {
-      plugins: [postcssPlugin()],
+      postcssOptions: {
+        plugins: [postcssPlugin()],
+      },
       config: false,
     });
     const stats = await compile(compiler);

--- a/test/options/__snapshots__/plugins.test.js.snap
+++ b/test/options/__snapshots__/plugins.test.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Options Plugins should disables plugin from config: css 1`] = `
+"a {
+  -x-border-color: blue blue *;
+  -x-color: * #fafafa;
+}
+"
+`;
+
+exports[`Options Plugins should disables plugin from config: errors 1`] = `Array []`;
+
+exports[`Options Plugins should disables plugin from config: warnings 1`] = `Array []`;
+
 exports[`Options Plugins should emit error on load plugin: errors 1`] = `
 Array [
   "ModuleBuildError: Module build failed (from \`replaced original path\`):
@@ -11,26 +23,10 @@ Loading PostCSS Plugin failed: Cannot find module 'postcss-unresolved' from 'src
 
 exports[`Options Plugins should emit error on load plugin: warnings 1`] = `Array []`;
 
-exports[`Options Plugins should not disables plugin from config: css 1`] = `
-"a {
-  border-top-color: blue;
-  border-right-color: blue;
-  border-left-color: blue;
-  background-color: #fafafa;
-}
-"
-`;
-
-exports[`Options Plugins should not disables plugin from config: errors 1`] = `Array []`;
-
-exports[`Options Plugins should not disables plugin from config: warnings 1`] = `Array []`;
-
 exports[`Options Plugins should work Plugins - { Array } Array + options: css 1`] = `
 "a {
-  border-top-color: blue;
-  border-right-color: blue;
-  border-left-color: blue;
-  background-color: #fafafa;
+  -x-border-color: blue blue *;
+  -x-color: * #fafafa;
 }
 "
 `;
@@ -38,20 +34,6 @@ exports[`Options Plugins should work Plugins - { Array } Array + options: css 1`
 exports[`Options Plugins should work Plugins - { Array } Array + options: errors 1`] = `Array []`;
 
 exports[`Options Plugins should work Plugins - { Array } Array + options: warnings 1`] = `Array []`;
-
-exports[`Options Plugins should work Plugins - { Function } Array + options: css 1`] = `
-"a {
-  border-top-color: blue;
-  border-right-color: blue;
-  border-left-color: blue;
-  background-color: #fafafa;
-}
-"
-`;
-
-exports[`Options Plugins should work Plugins - { Function } Array + options: errors 1`] = `Array []`;
-
-exports[`Options Plugins should work Plugins - { Function } Array + options: warnings 1`] = `Array []`;
 
 exports[`Options Plugins should work Plugins - {Array<Object>} + options: css 1`] = `
 "a {
@@ -141,7 +123,7 @@ exports[`Options Plugins should work Plugins - {Object}: errors 1`] = `Array []`
 exports[`Options Plugins should work Plugins - {Object}: warnings 1`] = `Array []`;
 
 exports[`Options Plugins should work Plugins - {empty Object}: css 1`] = `
-"a { color: rgba(255, 0, 0, 1.0) }
+"a { color: black }
 "
 `;
 

--- a/test/options/__snapshots__/postcssOptins.test.js.snap
+++ b/test/options/__snapshots__/postcssOptins.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Postcss options should work "from", "to" and "map" postcssOptions: css 1`] = `
+"a { color: black }
+"
+`;
+
+exports[`Postcss options should work "from", "to" and "map" postcssOptions: errors 1`] = `Array []`;
+
+exports[`Postcss options should work "from", "to" and "map" postcssOptions: map 1`] = `
+Object {
+  "file": "x",
+  "mappings": "AAAA,IAAI,aAAa",
+  "names": Array [],
+  "sources": Array [
+    "xxx",
+  ],
+  "sourcesContent": Array [
+    "a { color: black }
+",
+  ],
+  "version": 3,
+}
+`;
+
+exports[`Postcss options should work "from", "to" and "map" postcssOptions: warnings 1`] = `Array []`;

--- a/test/options/config.test.js
+++ b/test/options/config.test.js
@@ -13,7 +13,9 @@ const testDirectory = path.resolve(__dirname, '../fixtures', 'config-autoload');
 describe('Config Options', () => {
   it('should work Config - false', async () => {
     const compiler = getCompiler('./config-scope/css/index.js', {
-      config: false,
+      postcssOptions: {
+        config: false,
+      },
     });
     const stats = await compile(compiler);
 
@@ -26,7 +28,9 @@ describe('Config Options', () => {
 
   it('should work Config - true', async () => {
     const compiler = getCompiler('./config-scope/css/index.js', {
-      config: true,
+      postcssOptions: {
+        config: true,
+      },
     });
     const stats = await compile(compiler);
 
@@ -39,10 +43,12 @@ describe('Config Options', () => {
 
   it('should work Config - "string"', async () => {
     const compiler = getCompiler('./config-scope/css/index.js', {
-      config: path.resolve(
-        __dirname,
-        '../fixtures/config-scope/css/custom.config.js'
-      ),
+      postcssOptions: {
+        config: path.resolve(
+          __dirname,
+          '../fixtures/config-scope/css/custom.config.js'
+        ),
+      },
     });
     const stats = await compile(compiler);
 
@@ -55,7 +61,9 @@ describe('Config Options', () => {
 
   it('should work Config - "string" with relative path', async () => {
     const compiler = getCompiler('./config-scope/css/index.js', {
-      config: 'test/fixtures/config-scope/css/custom.config.js',
+      postcssOptions: {
+        config: 'test/fixtures/config-scope/css/custom.config.js',
+      },
     });
     const stats = await compile(compiler);
 
@@ -68,7 +76,9 @@ describe('Config Options', () => {
 
   it('should work Config - "string" with path directory', async () => {
     const compiler = getCompiler('./config-scope/css/index.js', {
-      config: 'test/fixtures/config-scope',
+      postcssOptions: {
+        config: 'test/fixtures/config-scope',
+      },
     });
     const stats = await compile(compiler);
 
@@ -81,11 +91,13 @@ describe('Config Options', () => {
 
   it('should work Config - Object - path file', async () => {
     const compiler = getCompiler('./config-scope/css/index.js', {
-      config: {
-        path: path.resolve(
-          __dirname,
-          '../fixtures/config-scope/css/custom.config.js'
-        ),
+      postcssOptions: {
+        config: {
+          path: path.resolve(
+            __dirname,
+            '../fixtures/config-scope/css/custom.config.js'
+          ),
+        },
       },
     });
     const stats = await compile(compiler);
@@ -110,7 +122,9 @@ describe('Config Options', () => {
 
   it('should work Config - Path - {String}', async () => {
     const compiler = getCompiler('./config-scope/css/index.js', {
-      config: { path: 'test/fixtures/config-scope/config/postcss.config.js' },
+      postcssOptions: {
+        config: { path: 'test/fixtures/config-scope/config/postcss.config.js' },
+      },
     });
     const stats = await compile(compiler);
 
@@ -123,9 +137,11 @@ describe('Config Options', () => {
 
   it('should work Config - Context - {Object}', async () => {
     const compiler = getCompiler('./config-scope/css/index.js', {
-      config: {
-        path: 'test/fixtures/config-scope/config/postcss.config.js',
-        ctx: { plugin: true },
+      postcssOptions: {
+        config: {
+          path: 'test/fixtures/config-scope/config/postcss.config.js',
+          ctx: { plugin: true },
+        },
       },
     });
     const stats = await compile(compiler);
@@ -139,8 +155,10 @@ describe('Config Options', () => {
 
   it('should work Config – Context – Loader {Object}', async () => {
     const compiler = getCompiler('./css/index.js', {
-      config: {
-        path: 'test/fixtures/config-scope/config/context/postcss.config.js',
+      postcssOptions: {
+        config: {
+          path: 'test/fixtures/config-scope/config/context/postcss.config.js',
+        },
       },
     });
     const stats = await compile(compiler);
@@ -156,9 +174,11 @@ describe('Config Options', () => {
 
   it('should work postcss.config.js - {Object} - Process CSS', async () => {
     const compiler = getCompiler('./config-autoload/js/object/index.js', {
-      config: {
-        path: path.resolve(testDirectory, 'js/object'),
-        ctx: { parser: false, syntax: false },
+      postcssOptions: {
+        config: {
+          path: path.resolve(testDirectory, 'js/object'),
+          ctx: { parser: false, syntax: false },
+        },
       },
     });
     const stats = await compile(compiler);
@@ -172,9 +192,11 @@ describe('Config Options', () => {
 
   it('should work postcss.config.js - {Array} - Process CSS', async () => {
     const compiler = getCompiler('./config-autoload/js/array/index.js', {
-      config: {
-        path: path.resolve(testDirectory, 'js/array'),
-        ctx: { parser: false, syntax: false },
+      postcssOptions: {
+        config: {
+          path: path.resolve(testDirectory, 'js/array'),
+          ctx: { parser: false, syntax: false },
+        },
       },
     });
     const stats = await compile(compiler);
@@ -188,8 +210,10 @@ describe('Config Options', () => {
 
   it('should work package.json - {Object} - Process CSS', async () => {
     const compiler = getCompiler('./config-autoload/pkg/index.js', {
-      config: {
-        path: path.resolve(testDirectory, 'pkg'),
+      postcssOptions: {
+        config: {
+          path: path.resolve(testDirectory, 'pkg'),
+        },
       },
     });
     const stats = await compile(compiler);
@@ -203,10 +227,12 @@ describe('Config Options', () => {
 
   it('should emit error when unresolved config ', async () => {
     const compiler = getCompiler('./config-scope/css/index.js', {
-      config: path.resolve(
-        __dirname,
-        '../fixtures/config-scope/css/unresolve.js'
-      ),
+      postcssOptions: {
+        config: path.resolve(
+          __dirname,
+          '../fixtures/config-scope/css/unresolve.js'
+        ),
+      },
     });
     const stats = await compile(compiler);
 
@@ -216,10 +242,12 @@ describe('Config Options', () => {
 
   it('should emit error when invalid config ', async () => {
     const compiler = getCompiler('./config-scope/css/index.js', {
-      config: path.resolve(
-        __dirname,
-        '../fixtures/config-scope/css/invalid.config.js'
-      ),
+      postcssOptions: {
+        config: path.resolve(
+          __dirname,
+          '../fixtures/config-scope/css/invalid.config.js'
+        ),
+      },
     });
     const stats = await compile(compiler);
 

--- a/test/options/exec.test.js
+++ b/test/options/exec.test.js
@@ -58,7 +58,11 @@ describe('Options Exec', () => {
                 },
                 {
                   loader: path.resolve(__dirname, '../../src'),
-                  options: { parser: 'postcss-js' },
+                  options: {
+                    postcssOptions: {
+                      parser: 'postcss-js',
+                    },
+                  },
                 },
               ],
             },

--- a/test/options/parser.test.js
+++ b/test/options/parser.test.js
@@ -25,7 +25,11 @@ describe('Options Parser', () => {
                 },
                 {
                   loader: path.resolve(__dirname, '../../src'),
-                  options: { parser: 'sugarss' },
+                  options: {
+                    postcssOptions: {
+                      parser: 'sugarss',
+                    },
+                  },
                 },
               ],
             },
@@ -60,8 +64,10 @@ describe('Options Parser', () => {
                   loader: path.resolve(__dirname, '../../src'),
                   // eslint-disable-next-line global-require
                   options: {
-                    // eslint-disable-next-line global-require,import/no-dynamic-require
-                    parser: require('sugarss'),
+                    postcssOptions: {
+                      // eslint-disable-next-line global-require,import/no-dynamic-require
+                      parser: require('sugarss'),
+                    },
                   },
                 },
               ],
@@ -97,8 +103,10 @@ describe('Options Parser', () => {
                   loader: path.resolve(__dirname, '../../src'),
                   // eslint-disable-next-line global-require
                   options: {
-                    // eslint-disable-next-line global-require,import/no-dynamic-require
-                    parser: require('sugarss').parse,
+                    postcssOptions: {
+                      // eslint-disable-next-line global-require,import/no-dynamic-require
+                      parser: require('sugarss').parse,
+                    },
                   },
                 },
               ],
@@ -132,7 +140,11 @@ describe('Options Parser', () => {
                 },
                 {
                   loader: path.resolve(__dirname, '../../src'),
-                  options: { parser: 'unresolve' },
+                  options: {
+                    postcssOptions: {
+                      parser: 'unresolve',
+                    },
+                  },
                 },
               ],
             },

--- a/test/options/plugins.test.js
+++ b/test/options/plugins.test.js
@@ -11,7 +11,7 @@ describe('Options Plugins', () => {
     const compiler = getCompiler('./css/index.js', {
       postcssOptions: {
         // eslint-disable-next-line global-require
-        plugins: [require('../fixtures/config/plugin')()],
+        plugins: [require('../fixtures/config-scope/config/plugin')()],
       },
     });
     const stats = await compile(compiler);
@@ -27,7 +27,7 @@ describe('Options Plugins', () => {
     const compiler = getCompiler('./css/index.js', {
       postcssOptions: {
         // eslint-disable-next-line global-require
-        plugins: require('../fixtures/config/plugin'),
+        plugins: require('../fixtures/config-scope/config/plugin'),
       },
     });
     const stats = await compile(compiler);
@@ -43,7 +43,7 @@ describe('Options Plugins', () => {
     const compiler = getCompiler('./css/index.js', {
       postcssOptions: {
         // eslint-disable-next-line global-require
-        plugins: () => [require('../fixtures/config/plugin')()],
+        plugins: () => [require('../fixtures/config-scope/config/plugin')()],
       },
     });
     const stats = await compile(compiler);
@@ -59,7 +59,7 @@ describe('Options Plugins', () => {
     const compiler = getCompiler('./css/index.js', {
       postcssOptions: {
         // eslint-disable-next-line global-require
-        plugins: () => require('../fixtures/config/plugin')(),
+        plugins: () => require('../fixtures/config-scope/config/plugin')(),
       },
     });
     const stats = await compile(compiler);

--- a/test/options/plugins.test.js
+++ b/test/options/plugins.test.js
@@ -9,8 +9,10 @@ import {
 describe('Options Plugins', () => {
   it('should work Plugins - {Array}', async () => {
     const compiler = getCompiler('./css/index.js', {
-      // eslint-disable-next-line global-require
-      plugins: [require('../fixtures/config-scope/config/plugin')()],
+      postcssOptions: {
+        // eslint-disable-next-line global-require
+        plugins: [require('../fixtures/config/plugin')()],
+      },
     });
     const stats = await compile(compiler);
 
@@ -23,8 +25,10 @@ describe('Options Plugins', () => {
 
   it('should work Plugins - {Object}', async () => {
     const compiler = getCompiler('./css/index.js', {
-      // eslint-disable-next-line global-require
-      plugins: require('../fixtures/config-scope/config/plugin'),
+      postcssOptions: {
+        // eslint-disable-next-line global-require
+        plugins: require('../fixtures/config/plugin'),
+      },
     });
     const stats = await compile(compiler);
 
@@ -37,8 +41,10 @@ describe('Options Plugins', () => {
 
   it('should work Plugins - {Function} - {Array}', async () => {
     const compiler = getCompiler('./css/index.js', {
-      // eslint-disable-next-line global-require
-      plugins: () => [require('../fixtures/config-scope/config/plugin')()],
+      postcssOptions: {
+        // eslint-disable-next-line global-require
+        plugins: () => [require('../fixtures/config/plugin')()],
+      },
     });
     const stats = await compile(compiler);
 
@@ -51,8 +57,10 @@ describe('Options Plugins', () => {
 
   it('should work Plugins - {Function} - {Object}', async () => {
     const compiler = getCompiler('./css/index.js', {
-      // eslint-disable-next-line global-require
-      plugins: () => require('../fixtures/config-scope/config/plugin')(),
+      postcssOptions: {
+        // eslint-disable-next-line global-require
+        plugins: () => require('../fixtures/config/plugin')(),
+      },
     });
     const stats = await compile(compiler);
 
@@ -65,9 +73,11 @@ describe('Options Plugins', () => {
 
   it('should work Plugins - {Object without require}', async () => {
     const compiler = getCompiler('./css/index.js', {
-      plugins: {
-        'postcss-import': {},
-        'postcss-nested': {},
+      postcssOptions: {
+        plugins: {
+          'postcss-import': {},
+          'postcss-nested': {},
+        },
       },
     });
     const stats = await compile(compiler);
@@ -80,8 +90,10 @@ describe('Options Plugins', () => {
   });
 
   it('should work Plugins - {empty Object}', async () => {
-    const compiler = getCompiler('./config-scope/css/index.js', {
-      plugins: {},
+    const compiler = getCompiler('./css/index.js', {
+      postcssOptions: {
+        plugins: {},
+      },
     });
     const stats = await compile(compiler);
 
@@ -94,8 +106,10 @@ describe('Options Plugins', () => {
 
   it('should work Plugins - {Object without require} + options', async () => {
     const compiler = getCompiler('./css/index2.js', {
-      plugins: {
-        'postcss-short': { prefix: 'x' },
+      postcssOptions: {
+        plugins: {
+          'postcss-short': { prefix: 'x' },
+        },
       },
     });
     const stats = await compile(compiler);
@@ -109,8 +123,10 @@ describe('Options Plugins', () => {
 
   it('should work Plugins - {Object} + options', async () => {
     const compiler = getCompiler('./css/index2.js', {
-      // eslint-disable-next-line global-require
-      plugins: require('postcss-short')({ prefix: 'x' }),
+      postcssOptions: {
+        // eslint-disable-next-line global-require
+        plugins: require('postcss-short')({ prefix: 'x' }),
+      },
     });
     const stats = await compile(compiler);
 
@@ -138,16 +154,11 @@ describe('Options Plugins', () => {
     expect(getErrors(stats)).toMatchSnapshot('errors');
   });
 
-  it('should work Plugins - { Function } Array + options', async () => {
+  it('should work Plugins - {Array<Object>} + options', async () => {
     const compiler = getCompiler('./css/index2.js', {
-      plugins: (loader) => {
-        expect(loader).toBeDefined();
-
-        return [
-          'postcss-nested',
-          ['postcss-import', { root: loader.resourcePath }],
-          ['postcss-short', { prefix: 'x' }],
-        ];
+      postcssOptions: {
+        // eslint-disable-next-line global-require
+        plugins: [require('postcss-short')({ prefix: 'x' })],
       },
     });
     const stats = await compile(compiler);
@@ -159,24 +170,14 @@ describe('Options Plugins', () => {
     expect(getErrors(stats)).toMatchSnapshot('errors');
   });
 
-  it('should work Plugins - {Array<Object>} + options', async () => {
+  it('should disables plugin from config', async () => {
     const compiler = getCompiler('./css/index2.js', {
-      // eslint-disable-next-line global-require
-      plugins: [require('postcss-short')({ prefix: 'x' })],
-    });
-    const stats = await compile(compiler);
-
-    const codeFromBundle = getCodeFromBundle('style2.css', stats);
-
-    expect(codeFromBundle.css).toMatchSnapshot('css');
-    expect(getWarnings(stats)).toMatchSnapshot('warnings');
-    expect(getErrors(stats)).toMatchSnapshot('errors');
-  });
-
-  it('should not disables plugin from config', async () => {
-    const compiler = getCompiler('./css/index2.js', {
-      config: 'test/fixtures/config-scope/css/plugins.config.js',
-      plugins: [['postcss-short', false]],
+      config: 'test/fixtures/css/plugins.config.js',
+      postcssOptions: {
+        plugins: {
+          'postcss-short': false,
+        },
+      },
     });
     const stats = await compile(compiler);
 
@@ -189,8 +190,10 @@ describe('Options Plugins', () => {
 
   it('should emit error on load plugin', async () => {
     const compiler = getCompiler('./css/index2.js', {
-      plugins: {
-        'postcss-unresolved': {},
+      postcssOptions: {
+        plugins: {
+          'postcss-unresolved': {},
+        },
       },
     });
     const stats = await compile(compiler);

--- a/test/options/postcssOptins.test.js
+++ b/test/options/postcssOptins.test.js
@@ -1,0 +1,42 @@
+import {
+  compile,
+  getCompiler,
+  getErrors,
+  getCodeFromBundle,
+  getWarnings,
+} from '../helpers/index';
+
+describe('Postcss options', () => {
+  it('should work "from", "to" and "map" postcssOptions', async () => {
+    const compiler = getCompiler('./css/index.js', {
+      postcssOptions: {
+        from: '/test/from.css',
+        to: '/test/to.css',
+        map: { inline: false, annotation: false },
+      },
+      config: false,
+    });
+    const stats = await compile(compiler);
+
+    const codeFromBundle = getCodeFromBundle('style.css', stats);
+    const notNormalizecodeFromBundle = getCodeFromBundle(
+      'style.css',
+      stats,
+      false
+    );
+
+    const toIsWork = notNormalizecodeFromBundle.map.file.endsWith('to.css');
+    const fromIsWork =
+      notNormalizecodeFromBundle.map.sources.filter((i) =>
+        i.endsWith('from.css')
+      ).length > 0;
+
+    expect(toIsWork).toBe(true);
+    expect(fromIsWork).toBe(true);
+
+    expect(codeFromBundle.css).toMatchSnapshot('css');
+    expect(codeFromBundle.map).toMatchSnapshot('map');
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+  });
+});

--- a/test/options/postcssOptins.test.js
+++ b/test/options/postcssOptins.test.js
@@ -7,14 +7,13 @@ import {
 } from '../helpers/index';
 
 describe('Postcss options', () => {
-  it('should work "from", "to" and "map" postcssOptions', async () => {
+  it.only('should work "from", "to" and "map" postcssOptions', async () => {
     const compiler = getCompiler('./css/index.js', {
       postcssOptions: {
         from: '/test/from.css',
         to: '/test/to.css',
         map: { inline: false, annotation: false },
       },
-      config: false,
     });
     const stats = await compile(compiler);
 

--- a/test/options/stringifier.test.js
+++ b/test/options/stringifier.test.js
@@ -9,7 +9,9 @@ import {
 describe('Options Stringifier', () => {
   it('should work Stringifier - {String}', async () => {
     const compiler = getCompiler('./css/index.js', {
-      stringifier: 'sugarss',
+      postcssOptions: {
+        stringifier: 'sugarss',
+      },
     });
     const stats = await compile(compiler);
 
@@ -22,8 +24,10 @@ describe('Options Stringifier', () => {
 
   it('should work Stringifier - {Object}', async () => {
     const compiler = getCompiler('./css/index.js', {
-      // eslint-disable-next-line global-require
-      stringifier: require('sugarss'),
+      postcssOptions: {
+        // eslint-disable-next-line global-require
+        stringifier: require('sugarss'),
+      },
     });
     const stats = await compile(compiler);
 
@@ -40,8 +44,9 @@ describe('Options Stringifier', () => {
     const midas = new Midas();
 
     const compiler = getCompiler('./css/index.js', {
-      // eslint-disable-next-line global-require
-      stringifier: midas.stringifier,
+      postcssOptions: {
+        stringifier: midas.stringifier,
+      },
     });
     const stats = await compile(compiler);
 
@@ -54,8 +59,9 @@ describe('Options Stringifier', () => {
 
   it('should emit error Stringifier', async () => {
     const compiler = getCompiler('./css/index.js', {
-      // eslint-disable-next-line global-require
-      stringifier: 'unresolved',
+      postcssOptions: {
+        stringifier: 'unresolved',
+      },
     });
     const stats = await compile(compiler);
 

--- a/test/options/syntax.test.js
+++ b/test/options/syntax.test.js
@@ -25,7 +25,11 @@ describe('Options Syntax', () => {
                 },
                 {
                   loader: path.resolve(__dirname, '../../src'),
-                  options: { syntax: 'sugarss' },
+                  options: {
+                    postcssOptions: {
+                      syntax: 'sugarss',
+                    },
+                  },
                 },
               ],
             },
@@ -59,8 +63,10 @@ describe('Options Syntax', () => {
                 {
                   loader: path.resolve(__dirname, '../../src'),
                   options: {
-                    // eslint-disable-next-line global-require
-                    syntax: require('sugarss'),
+                    postcssOptions: {
+                      // eslint-disable-next-line global-require
+                      syntax: require('sugarss'),
+                    },
                   },
                 },
               ],
@@ -95,7 +101,11 @@ describe('Options Syntax', () => {
                 },
                 {
                   loader: path.resolve(__dirname, '../../src'),
-                  options: { syntax: 'unresolve' },
+                  options: {
+                    postcssOptions: {
+                      syntax: 'unresolve',
+                    },
+                  },
                 },
               ],
             },

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -22,32 +22,45 @@ describe('validate options', () => {
       success: [false],
       failure: [1, 'test', /test/, [], {}, { foo: 'bar' }],
     },
-    parser: {
-      success: ['sugarss', require('sugarss'), require('sugarss').parse],
-      failure: [1, true, false, []],
-    },
-    syntax: {
-      success: ['sugarss', require('sugarss')],
-      failure: [1, true, false, []],
-    },
-    stringifier: {
-      success: ['sugarss', require('sugarss'), require('sugarss').stringify],
-      failure: [1, true, false, []],
+    postcssOptions: {
+      success: [
+        { parser: 'sugarss' },
+        { parser: require('sugarss') },
+        { parser: require('sugarss').parse },
+        { syntax: 'sugarss' },
+        { syntax: require('sugarss') },
+        { stringifier: 'sugarss' },
+        { stringifier: require('sugarss') },
+        { stringifier: require('sugarss').stringify },
+        { plugins: () => require('./fixtures/config/plugin')() },
+        { plugins: () => [require('./fixtures/config/plugin')()] },
+        {
+          plugins: [
+            require('./fixtures/config/plugin')(),
+            require('./fixtures/config/plugin'),
+            { 'postcss-short': { prefix: 'x' } },
+          ],
+        },
+        { plugins: { 'postcss-short': { prefix: 'x' } } },
+      ],
+      failure: [
+        { parser: 1 },
+        { parser: true },
+        { parser: [] },
+        { syntax: 1 },
+        { syntax: true },
+        { syntax: [] },
+        { stringifier: 1 },
+        { stringifier: true },
+        { stringifier: [] },
+        { plugins: 1 },
+        { plugins: true },
+        { plugins: 'postcss-short' },
+      ],
     },
     sourceMap: {
       success: ['source-map', true],
       failure: [1, /test/, [], {}],
-    },
-    plugins: {
-      success: [
-        [require('./fixtures/config-scope/config/plugin')()],
-        require('./fixtures/config-scope/config/plugin'),
-        () => [require('./fixtures/config-scope/config/plugin')()],
-        [['postcss-short', false]],
-        [['postcss-short', { prefix: 'x' }]],
-        ['postcss-short'],
-      ],
-      failure: [1, true, false],
     },
   };
 
@@ -68,7 +81,11 @@ describe('validate options', () => {
     } the "${key}" option with "${stringifyValue(value)}" value`, async () => {
       let compiler;
 
-      if (key === 'parser' || key === 'syntax') {
+      if (
+        key === 'postcssOptions' &&
+        // eslint-disable-next-line no-prototype-builtins
+        (value.hasOwnProperty('parser') || value.hasOwnProperty('syntax'))
+      ) {
         compiler = getCompiler(
           './sss/index.js',
           {},

--- a/test/validate-options.test.js
+++ b/test/validate-options.test.js
@@ -5,19 +5,6 @@ import { getCompiler, compile } from './helpers/index';
 
 describe('validate options', () => {
   const tests = {
-    config: {
-      success: [
-        { path: 'test/fixtures/config-scope/config/postcss.config.js' },
-        {
-          path: 'test/fixtures/config-scope/config/postcss.config.js',
-          ctx: { plugin: true },
-        },
-        true,
-        false,
-        'test/fixtures/config-scope/config/postcss.config.js',
-      ],
-      failure: [[], { foo: 'bar' }],
-    },
     exec: {
       success: [false],
       failure: [1, 'test', /test/, [], {}, { foo: 'bar' }],
@@ -32,16 +19,30 @@ describe('validate options', () => {
         { stringifier: 'sugarss' },
         { stringifier: require('sugarss') },
         { stringifier: require('sugarss').stringify },
-        { plugins: () => require('./fixtures/config/plugin')() },
-        { plugins: () => [require('./fixtures/config/plugin')()] },
+        { plugins: () => require('./fixtures/config-scope/config/plugin')() },
+        { plugins: () => [require('./fixtures/config-scope/config/plugin')()] },
         {
           plugins: [
-            require('./fixtures/config/plugin')(),
-            require('./fixtures/config/plugin'),
+            require('./fixtures/config-scope/config/plugin')(),
+            require('./fixtures/config-scope/config/plugin'),
             { 'postcss-short': { prefix: 'x' } },
           ],
         },
         { plugins: { 'postcss-short': { prefix: 'x' } } },
+        { config: true },
+        { config: false },
+        { config: 'test/fixtures/config-scope/config/postcss.config.js' },
+        {
+          config: {
+            path: 'test/fixtures/config-scope/config/postcss.config.js',
+          },
+        },
+        {
+          config: {
+            path: 'test/fixtures/config-scope/config/postcss.config.js',
+            ctx: { plugin: true },
+          },
+        },
       ],
       failure: [
         { parser: 1 },
@@ -56,6 +57,7 @@ describe('validate options', () => {
         { plugins: 1 },
         { plugins: true },
         { plugins: 'postcss-short' },
+        { config: [] },
       ],
     },
     sourceMap: {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

Extract postcssOptions in options.postcssOptions

### Breaking Changes

Moved options:
- options.plugins -> options.postcssOptions.plugins
- options.parser -> options.postcssOptions.parser 
- options.syntax -> options.postcssOptions.syntax 
- options.stringifier -> options.postcssOptions.stringifier 

### Additional Info

No

