### PR TITLE
Add support for registering webpack build dependencies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,6 +124,10 @@ export default async function loader(content, sourceMap, meta) {
       this.addDependency(message.file);
     }
 
+    if (message.type === "build-dependency") {
+      this.addBuildDependency(message.file);
+    }
+
     if (message.type === "asset" && message.content && message.file) {
       this.emitFile(
         message.file,

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -106,6 +106,10 @@ Warning
 ]
 `;
 
+exports[`loader should register dependencies using the "messages" API: errors 1`] = `Array []`;
+
+exports[`loader should register dependencies using the "messages" API: warnings 1`] = `Array []`;
+
 exports[`loader should reuse PostCSS AST: css 1`] = `
 "a {
   color: black;


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Allow plugins to register build dependencies to properly handle webpack 5 persistent cache invalidation.

### Breaking Changes

None.

### Additional Info

N/A