### PR TITLE
feat: add support for `dir-dependency` message type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,6 +134,9 @@ export default async function loader(content, sourceMap, meta) {
       case "context-dependency":
         this.addContextDependency(message.file);
         break;
+      case "dir-dependency":
+        this.addContextDependency(message.dir);
+        break;
       case "asset":
         if (message.content && message.file) {
           this.emitFile(

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -101,6 +101,12 @@ describe("loader", () => {
           file: path.resolve(__dirname, "fixtures", "deps"),
           content: "",
           plugin,
+        },
+        {
+          type: "dir-dependency",
+          dir: path.resolve(__dirname, "fixtures", "deps2"),
+          content: "",
+          plugin,
         }
       );
     };
@@ -121,6 +127,9 @@ describe("loader", () => {
 
     expect(contextDependencies).toContain(
       path.resolve(__dirname, "fixtures", "deps")
+    );
+    expect(contextDependencies).toContain(
+      path.resolve(__dirname, "fixtures", "deps2")
     );
     expect(missingDependencies).toContain(
       path.resolve(__dirname, "fixtures", "missing-dep.html")


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The [PostCSS documentation](https://github.com/postcss/postcss/blob/main/docs/guidelines/runner.md#3-dependencies) has been updated to include a new `dir-dependency` message type. To my understanding of webpack this should be functionally equivalent to the existing `context-dependency`.

**Side note: would it be possible to backport this to postcss-loader v4, so that webpack 4 users can benefit?**

_Please feel free to make any changes to this pull request._