### PR TITLE
docs: fix default value of config (#626)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,9 @@ There is the special `config` option for config files. How it works and how it c
 We recommend do not specify `from`, `to` and `map` options, because this can lead to wrong path in source maps.
 If you need source maps please use the [`sourcemap`](#sourcemap) option.
 
-To optimize performance of the loader, it is better to provide `postcssOptions` in loader config and specify `config: false`.
-This approach removes the need to lookup and load external config files multiple times during compilation.
+For large projects, to optimize performance of the loader, it is better to provide `postcssOptions` in loader
+config and specify `config: false`. This approach removes the need to lookup and load external config files multiple
+times during compilation.
 
 #### `object`
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ There is the special `config` option for config files. How it works and how it c
 We recommend do not specify `from`, `to` and `map` options, because this can lead to wrong path in source maps.
 If you need source maps please use the [`sourcemap`](#sourcemap) option.
 
+To optimize performance of the loader, it is better to provide `postcssOptions` in loader config and specify `config: false`.
+This approach removes the need to lookup and load external config files multiple times during compilation.
+
 #### `object`
 
 Setup `plugins`:
@@ -405,7 +408,7 @@ Type:
 type config = boolean | string;
 ```
 
-Default: `undefined`
+Default: `true`
 
 Allows to set options using config files.
 Options specified in the config file are combined with options passed to the loader, the loader options overwrite options from config.


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Fix the default value of `config` in docs to match the implementation.

Added a note suggesting to disable automatic `config` for performance reason (for example, in our big monorepo with thousands of css files we see 10-20 second improvement for the big 10 minute build).
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

None
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
