### PR TITLE
fix: duplicate init typescriptLoader

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -34,6 +34,8 @@ function exec(code, loaderContext) {
   return module.exports;
 }
 
+let tsloader;
+
 async function loadConfig(loaderContext, config, postcssOptions) {
   const searchPath =
     typeof config === "string"
@@ -166,13 +168,15 @@ async function loadConfig(loaderContext, config, postcssOptions) {
   };
 
   if (isTsNodeInstalled) {
-    // eslint-disable-next-line global-require
-    const { TypeScriptLoader } = require("cosmiconfig-typescript-loader");
-    const loader = TypeScriptLoader();
+    if(!tsLoader) {
+      // eslint-disable-next-line global-require
+      const { TypeScriptLoader } = require("cosmiconfig-typescript-loader");
+      tsLoader = TypeScriptLoader();
+    }
 
-    loaders[".cts"] = loader;
-    loaders[".mts"] = loader;
-    loaders[".ts"] = loader;
+    loaders[".cts"] = tsLoader;
+    loaders[".mts"] = tsLoader;
+    loaders[".ts"] = tsLoader;
   }
 
   const explorer = cosmiconfig(moduleName, {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
Each time the `typescriptLoader` is executed, ts-node will execute `registerExtension()` once.

Multiple executions of the `typescriptLoader` will get
`require.extensions[ext] = wrapper(wrapper(wrapper(wrapper(wrapper(... wrapper(originalHandler)))))`.
[ts-node source code](https://github.com/TypeStrong/ts-node/blob/71dcfd7b813a4178d89562bb4c28d7d6579fae4f/src/index.ts#L1532)

This will cause the out of memory when `require.extensions[ext]` is executed. #638
