### PR TITLE
fix: use `cause` to keep original errors and warnings

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -559,55 +559,55 @@ function reportError(loaderContext, callback, error) {
   }
 }
 
-function warningFactory(obj) {
+function warningFactory(warning) {
   let message = "";
 
-  if (typeof obj.line !== "undefined") {
-    message += `(${obj.line}:${obj.column}) `;
+  if (typeof warning.line !== "undefined") {
+    message += `(${warning.line}:${warning.column}) `;
   }
 
-  if (typeof obj.plugin !== "undefined") {
-    message += `from "${obj.plugin}" plugin: `;
+  if (typeof warning.plugin !== "undefined") {
+    message += `from "${warning.plugin}" plugin: `;
   }
 
-  message += obj.text;
+  message += warning.text;
 
-  if (obj.node) {
-    message += `\n\nCode:\n  ${obj.node.toString()}\n`;
+  if (warning.node) {
+    message += `\n\nCode:\n  ${warning.node.toString()}\n`;
   }
 
-  const warning = new Error(message);
+  const obj = new Error(message, { cause: warning });
 
-  warning.stack = null;
+  obj.stack = null;
 
-  return warning;
+  return obj;
 }
 
-function syntaxErrorFactory(obj) {
+function syntaxErrorFactory(error) {
   let message = "\nSyntaxError\n\n";
 
-  if (typeof obj.line !== "undefined") {
-    message += `(${obj.line}:${obj.column}) `;
+  if (typeof error.line !== "undefined") {
+    message += `(${error.line}:${error.column}) `;
   }
 
-  if (typeof obj.plugin !== "undefined") {
-    message += `from "${obj.plugin}" plugin: `;
+  if (typeof error.plugin !== "undefined") {
+    message += `from "${error.plugin}" plugin: `;
   }
 
-  message += obj.file ? `${obj.file} ` : "<css input> ";
-  message += `${obj.reason}`;
+  message += error.file ? `${error.file} ` : "<css input> ";
+  message += `${error.reason}`;
 
-  const code = obj.showSourceCode();
+  const code = error.showSourceCode();
 
   if (code) {
     message += `\n\n${code}\n`;
   }
 
-  const error = new Error(message);
+  const obj = new Error(message, { cause: error });
 
-  error.stack = null;
+  obj.stack = null;
 
-  return error;
+  return obj;
 }
 
 export {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

use `cause` to keep original error

### Breaking Changes

No

### Additional Info

I am preparing good error reporting for CSS in webpack 