### PR TITLE
fix: do not crash if pkg.(d|devD)ependencies unset

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -162,7 +162,9 @@ export default async function loader(content, sourceMap, meta) {
           }
 
           if (pkg) {
-            if (!pkg.dependencies.postcss && !pkg.devDependencies.postcss) {
+            const { dependencies = {}, devDependencies = {} } = pkg;
+
+            if (!dependencies.postcss && !devDependencies.postcss) {
               this.emitWarning(
                 new Error(
                   "Add postcss as project dependency. postcss is not a peer dependency for postcss-loader. " +

--- a/test/fixtures/package-json-files/no-postcss/package.json
+++ b/test/fixtures/package-json-files/no-postcss/package.json
@@ -1,4 +1,1 @@
-{
-  "dependencies": {},
-  "devDependencies": {}
-}
+{}

--- a/test/fixtures/package-json-files/postcss-v8-in-dependencies/package.json
+++ b/test/fixtures/package-json-files/postcss-v8-in-dependencies/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
     "postcss": "^8.0.0"
-  },
-  "devDependencies": {}
+  }
 }

--- a/test/fixtures/package-json-files/postcss-v8-in-devDependencies/package.json
+++ b/test/fixtures/package-json-files/postcss-v8-in-devDependencies/package.json
@@ -1,5 +1,4 @@
 {
-  "dependencies": {},
   "devDependencies": {
     "postcss": "^8.0.0"
   }


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Fixes #547. `dependencies` and `devDependencies` are not required fields of `package.json`, but the existing code assumes they are always present, which can throw an uncaught error.

### Breaking Changes

N/A

### Additional Info

I no longer use this library, but I got tired of my stale ticket sitting around in my issues list 😜 