### PR TITLE
test: sourcemaps with an actual plugin

### DIFF
--- a/test/__snapshots__/sourceMap.test.js.snap
+++ b/test/__snapshots__/sourceMap.test.js.snap
@@ -108,7 +108,7 @@ exports[`"sourceMap" option should generate source maps using the "postcssOption
 "a {
   color: coral;
 }
-/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0eWxlLnNjc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7RUFBSSIsImZpbGUiOiJzdHlsZS5zY3NzIiwic291cmNlc0NvbnRlbnQiOlsiYSB7XG4gIGNvbG9yOiBjb3JhbDtcbn0iXX0= */"
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInN0eWxlLnNjc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUE7RUFBSSxZQUFBO0FBRUoiLCJmaWxlIjoic3R5bGUuc2NzcyIsInNvdXJjZXNDb250ZW50IjpbImEgeyBjb2xvcjogY29yYWwgfVxuIl19 */"
 `;
 
 exports[`"sourceMap" option should generate source maps using the "postcssOptions.map" option with "true" value and previous loader returns source maps ("sass-loader"): errors 1`] = `[]`;
@@ -251,7 +251,7 @@ exports[`"sourceMap" option should generate source maps when value is not specif
 
 exports[`"sourceMap" option should generate source maps when value is not specified and the "devtool" with "source-map" value: source map 1`] = `
 {
-  "mappings": "AAAA",
+  "mappings": "AAAA;EACE,YAAY;AACd;;AAEA;EACE,UAAU;AACZ;;AAEA;EACE,YAAY;AACd;;AAEA;EACE,WAAW;AACb;;AAEA;EACE,4BAA4B;EAC5B,mBAAmB;AACrB;;AAEA;EACE,4BAA4B;EAC5B,mBAAmB;AACrB;;AAEA;EACE;IACE,YAAY;;IAEZ;MACE,WAAW;IACb;;IAEA;MACE,YAAY;IACd;EACF;;EAEA;IACE,cAAc;EAChB;AACF",
   "names": [],
   "sourceRoot": "",
   "sources": [
@@ -361,7 +361,7 @@ exports[`"sourceMap" option should generate source maps with "false" value, but 
 exports[`"sourceMap" option should generate source maps with "false" value, but the "postcssOptions.map" has values: source map 1`] = `
 {
   "file": "style.css",
-  "mappings": "AAAA",
+  "mappings": "AAAA;EACE,YAAY;AACd;;AAEA;EACE,UAAU;AACZ;;AAEA;EACE,YAAY;AACd;;AAEA;EACE,WAAW;AACb;;AAEA;EACE,4BAA4B;EAC5B,mBAAmB;AACrB;;AAEA;EACE,4BAA4B;EAC5B,mBAAmB;AACrB;;AAEA;EACE;IACE,YAAY;;IAEZ;MACE,WAAW;IACb;;IAEA;MACE,YAAY;IACd;EACF;;EAEA;IACE,cAAc;EAChB;AACF",
   "names": [],
   "sourceRoot": "",
   "sources": [
@@ -470,7 +470,7 @@ exports[`"sourceMap" option should generate source maps with "true" value and th
 
 exports[`"sourceMap" option should generate source maps with "true" value and the "devtool" option with "source-map" value: source map 1`] = `
 {
-  "mappings": "AAAA",
+  "mappings": "AAAA;EACE,YAAY;AACd;;AAEA;EACE,UAAU;AACZ;;AAEA;EACE,YAAY;AACd;;AAEA;EACE,WAAW;AACb;;AAEA;EACE,4BAA4B;EAC5B,mBAAmB;AACrB;;AAEA;EACE,4BAA4B;EAC5B,mBAAmB;AACrB;;AAEA;EACE;IACE,YAAY;;IAEZ;MACE,WAAW;IACb;;IAEA;MACE,YAAY;IACd;EACF;;EAEA;IACE,cAAc;EAChB;AACF",
   "names": [],
   "sourceRoot": "",
   "sources": [
@@ -579,7 +579,7 @@ exports[`"sourceMap" option should generate source maps with "true" value and th
 
 exports[`"sourceMap" option should generate source maps with "true" value and the "devtool" with "false" value: source map 1`] = `
 {
-  "mappings": "AAAA",
+  "mappings": "AAAA;EACE,YAAY;AACd;;AAEA;EACE,UAAU;AACZ;;AAEA;EACE,YAAY;AACd;;AAEA;EACE,WAAW;AACb;;AAEA;EACE,4BAA4B;EAC5B,mBAAmB;AACrB;;AAEA;EACE,4BAA4B;EAC5B,mBAAmB;AACrB;;AAEA;EACE;IACE,YAAY;;IAEZ;MACE,WAAW;IACb;;IAEA;MACE,YAAY;IACd;EACF;;EAEA;IACE,cAAc;EAChB;AACF",
   "names": [],
   "sourceRoot": "",
   "sources": [

--- a/test/sourceMap.test.js
+++ b/test/sourceMap.test.js
@@ -13,13 +13,24 @@ import {
   getWarnings,
 } from "./helpers";
 
+const noopPlugin = () => {
+  return {
+    postcssPlugin: "noop-plugin",
+    Rule() {
+      // do nothing
+    },
+  };
+};
+
+noopPlugin.postcss = true;
+
 describe('"sourceMap" option', () => {
   it('should generate source maps with "true" value and the "devtool" with "false" value', async () => {
     const compiler = getCompiler(
       "./css/index.js",
       {
         sourceMap: true,
-        postcssOptions: { hideNothingWarning: true },
+        postcssOptions: { hideNothingWarning: true, plugins: [noopPlugin] },
       },
       {
         devtool: false,
@@ -52,7 +63,7 @@ describe('"sourceMap" option', () => {
       "./css/index.js",
       {
         sourceMap: true,
-        postcssOptions: { hideNothingWarning: true },
+        postcssOptions: { hideNothingWarning: true, plugins: [noopPlugin] },
       },
       {
         devtool: "source-map",
@@ -84,7 +95,7 @@ describe('"sourceMap" option', () => {
     const compiler = getCompiler(
       "./css/index.js",
       {
-        postcssOptions: { hideNothingWarning: true },
+        postcssOptions: { hideNothingWarning: true, plugins: [noopPlugin] },
       },
       {
         devtool: "source-map",
@@ -124,6 +135,7 @@ describe('"sourceMap" option', () => {
             sourcesContent: true,
           },
           hideNothingWarning: true,
+          plugins: [noopPlugin],
         },
       },
       {
@@ -171,6 +183,7 @@ describe('"sourceMap" option', () => {
                     postcssOptions: {
                       map: true,
                       hideNothingWarning: true,
+                      plugins: [noopPlugin],
                     },
                   },
                 },


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

PostCSS has two modes:
- `LazyResult`
- `NoWorkResult`

`NoWorkResult` is an optimized path that is taken if no plugins, parsers, ... are provided.
The assumption here is that the user has a bad config and doesn't actually want to use PostCSS.

`LazyResult` is PostCSS actually doing things.

The sourcemaps generated for both modes are radically different.

This changes adds a noop plugin to trigger the `LazyResult` mode.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

N/A

### Additional Info

I don't know if this might surface subtle bugs here.
Main purpose is to have better test coverage.

I am trying to pinpoint the cause of this issue : https://github.com/postcss/postcss/issues/1914