### PR TITLE
fix(loadConfig): added fix when loading postcss esm configs

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -108,6 +108,10 @@ async function loadConfig(loaderContext, config, postcssOptions) {
         }
       }
 
+      if (result.default) {
+        return result.default;
+      }
+
       return result;
     },
     ".cjs": defaultLoadersSync[".cjs"],
@@ -128,6 +132,10 @@ async function loadConfig(loaderContext, config, postcssOptions) {
         result = await importESM(urlForConfig);
       } else {
         throw new Error("ESM is not supported");
+      }
+
+      if (result.default) {
+        return result.default;
       }
 
       return result;

--- a/test/config-autoload.test.js
+++ b/test/config-autoload.test.js
@@ -116,6 +116,45 @@ describe("autoload config", () => {
     );
   });
 
+  it('should load ESM version of "postcss.config.js" with "Array" syntax of plugins', async () => {
+    const loadedConfig = await loadConfig(
+      loaderContext,
+      path.resolve(testDirectory, "js/array-esm-js"),
+    );
+
+    expect(loadedConfig.config.map).toEqual(false);
+    expect(loadedConfig.config.from).toEqual(
+      "./test/fixtures/config-autoload/js/object/index.css",
+    );
+    expect(loadedConfig.config.to).toEqual(
+      "./test/fixtures/config-autoload/js/object/expect/index.css",
+    );
+    expect(Object.keys(loadedConfig.config.plugins).length).toEqual(4);
+    expect(loadedConfig.filepath).toEqual(
+      path.resolve(testDirectory, "js/array-esm-js", "postcss.config.js"),
+    );
+  });
+
+  // TODO Test manually with NODE_OPTIONS=--experimental-vm-modules to enable ESM support in jest
+  it.skip('should load "postcss.config.mjs" with "Array" syntax of plugins', async () => {
+    const loadedConfig = await loadConfig(
+      loaderContext,
+      path.resolve(testDirectory, "js/array-mjs"),
+    );
+
+    expect(loadedConfig.config.map).toEqual(false);
+    expect(loadedConfig.config.from).toEqual(
+      "./test/fixtures/config-autoload/js/object/index.css",
+    );
+    expect(loadedConfig.config.to).toEqual(
+      "./test/fixtures/config-autoload/js/object/expect/index.css",
+    );
+    expect(Object.keys(loadedConfig.config.plugins).length).toEqual(4);
+    expect(loadedConfig.filepath).toEqual(
+      path.resolve(testDirectory, "js/array-mjs", "postcss.config.mjs"),
+    );
+  });
+
   it('should load "postcss.config.ts" with "Array" syntax of plugins', async () => {
     const loadedConfig = await loadConfig(
       loaderContext,

--- a/test/fixtures/config-autoload/js/array-esm-js/imports/section.css
+++ b/test/fixtures/config-autoload/js/array-esm-js/imports/section.css
@@ -1,0 +1,3 @@
+.import {
+  color: goldenrod;
+}

--- a/test/fixtures/config-autoload/js/array-esm-js/index.css
+++ b/test/fixtures/config-autoload/js/array-esm-js/index.css
@@ -1,0 +1,5 @@
+@import 'imports/section.css';
+
+.test {
+  color: cyan;
+}

--- a/test/fixtures/config-autoload/js/array-esm-js/index.js
+++ b/test/fixtures/config-autoload/js/array-esm-js/index.js
@@ -1,0 +1,3 @@
+import style from './index.css'
+
+export default style

--- a/test/fixtures/config-autoload/js/array-esm-js/postcss.config.js
+++ b/test/fixtures/config-autoload/js/array-esm-js/postcss.config.js
@@ -1,0 +1,21 @@
+import postcssNested from 'postcss-nested';
+export default function (api) {
+  return {
+    parser: 'sugarss',
+    syntax: 'sugarss',
+    map: api.mode === 'development' ? 'inline' : false,
+    from: './test/fixtures/config-autoload/js/object/index.css',
+    to: './test/fixtures/config-autoload/js/object/expect/index.css',
+    plugins: [
+      'postcss-import',
+      [
+        'postcss-nested',
+        {
+          // Options
+        }
+      ],
+      postcssNested,
+      postcssNested({ /* Options */ }),
+    ]
+  }
+};

--- a/test/fixtures/config-autoload/js/array-mjs/imports/section.css
+++ b/test/fixtures/config-autoload/js/array-mjs/imports/section.css
@@ -1,0 +1,3 @@
+.import {
+  color: goldenrod;
+}

--- a/test/fixtures/config-autoload/js/array-mjs/index.css
+++ b/test/fixtures/config-autoload/js/array-mjs/index.css
@@ -1,0 +1,5 @@
+@import 'imports/section.css';
+
+.test {
+  color: cyan;
+}

--- a/test/fixtures/config-autoload/js/array-mjs/index.js
+++ b/test/fixtures/config-autoload/js/array-mjs/index.js
@@ -1,0 +1,3 @@
+import style from './index.css'
+
+export default style

--- a/test/fixtures/config-autoload/js/array-mjs/postcss.config.mjs
+++ b/test/fixtures/config-autoload/js/array-mjs/postcss.config.mjs
@@ -1,0 +1,21 @@
+import postcssNested from 'postcss-nested';
+export default function (api) {
+  return {
+    parser: 'sugarss',
+    syntax: 'sugarss',
+    map: api.mode === 'development' ? 'inline' : false,
+    from: './test/fixtures/config-autoload/js/object/index.css',
+    to: './test/fixtures/config-autoload/js/object/expect/index.css',
+    plugins: [
+      'postcss-import',
+      [
+        'postcss-nested',
+        {
+          // Options
+        }
+      ],
+      postcssNested,
+      postcssNested({ /* Options */ }),
+    ]
+  }
+};


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

I'm using a ESM version of postcss config in one of my projects (`postcss.config.mjs`) and noticed that postcss-loader did not pick up the configuration. This fixes that issue.

### Additional Info

One of the tests I added need to be run with `NODE_OPTIONS=--experimental-vm-modules` to enable ESM support in `jest`. Flip the test to `it.only` and run:

```
NODE_OPTIONS=--experimental-vm-modules npm run test:only -t 'config-autoload'
```
